### PR TITLE
Fix: Demo user navigation after survey submission

### DIFF
--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -109,7 +109,7 @@ export default function SurveyPage() {
   
   if (submitted) {
     const isTeamLead = user.hierarchyLevelId === 'level-4';
-    const dashboardPath = isTeamLead ? '/manager' : '/survey';
+    const dashboardPath = isTeamLead ? '/manager' : '/dashboard';
 
     return (
       <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-100 flex items-center justify-center p-4">

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,12 +12,14 @@ export function middleware(request: NextRequest) {
 
   if (userCookie && isLoginPage) {
     const user = JSON.parse(userCookie.value);
-    if (user.role === 'admin') {
+    if (user.isAdmin) {
       return NextResponse.redirect(new URL('/admin', request.url));
-    } else if (user.role === 'manager') {
+    } else if (user.hierarchyLevelId === 'level-5') {
+      return NextResponse.redirect(new URL('/survey', request.url));
+    } else if (user.hierarchyLevelId === 'level-4') {
       return NextResponse.redirect(new URL('/manager', request.url));
     } else {
-      return NextResponse.redirect(new URL('/survey', request.url));
+      return NextResponse.redirect(new URL('/dashboard', request.url));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixed two critical navigation bugs that prevented demo users (team members) from properly navigating after completing the survey:

- **Survey page**: Now redirects team members to `/dashboard` instead of `/survey` after submission, eliminating the circular navigation loop
- **Middleware**: Updated to use correct user properties (`isAdmin`, `hierarchyLevelId`) instead of the non-existent `role` property

## Changes

### 1. Survey Page Navigation (`app/survey/page.tsx`)
**Before:** Team members were redirected back to `/survey` after submission
**After:** Team members are redirected to `/dashboard` after submission

### 2. Middleware Routing Logic (`middleware.ts`)
**Before:** Used non-existent `user.role` property for routing decisions
**After:** Uses correct `user.isAdmin` and `user.hierarchyLevelId` properties

## Impact

This fix resolves the issue where demo users couldn't navigate back to the dashboard after clicking "Back to Dashboard" following survey submission.

## Testing

Tested with demo user credentials:
- Username: `demo`
- Password: `demo`
- User type: Team Member (hierarchyLevelId: 'level-5')

**Test Steps:**
1. Login as demo user
2. Complete health check survey
3. Submit responses
4. Click "Back to Dashboard"
5. ✅ User is now successfully redirected to dashboard

## Files Changed

- `app/survey/page.tsx` - Fixed dashboard path for team members
- `middleware.ts` - Fixed user property references in routing logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix navigation after survey submission for demo team members by redirecting to /dashboard instead of /survey, removing the loop. Updated middleware to use isAdmin and hierarchyLevelId for login redirects (admin -> /admin, level-5 -> /survey, level-4 -> /manager, others -> /dashboard).

<!-- End of auto-generated description by cubic. -->

