### PR TITLE
feat: hide trend for team members, add score band legend, add Excel export

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -579,7 +579,7 @@ export default function DashboardPage() {
                 <option key={period} value={period}>{period}</option>
               ))}
             </select>
-            {userPermissions.canExportData && individualResponses.length > 0 && (
+            {userPermissions.canExportData && healthSummary.length > 0 && (
               <button
                 data-testid="export-excel-btn"
                 onClick={handleExportToExcel}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -579,7 +579,7 @@ export default function DashboardPage() {
                 <option key={period} value={period}>{period}</option>
               ))}
             </select>
-            {(userPermissions.canExportData || userPermissions.canViewReports) && healthSummary.length > 0 && (
+            {userPermissions.canExportData && healthSummary.length > 0 && (
               <button
                 data-testid="export-excel-btn"
                 onClick={handleExportToExcel}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { getCurrentUser, logout, authenticatedFetch } from '@/lib/auth';
 import { HEALTH_DIMENSIONS } from '@/lib/data';
-import { getOrgConfig, getHierarchyLevel } from '@/lib/org-config';
-import { LogOut, Building2, ChevronDown, BarChart3, LineChart as LineChartIcon, Users as UsersIcon, Activity, ClipboardList, TrendingUp, TrendingDown, Minus, LayoutGrid, List, Info, CheckCircle } from 'lucide-react';
+import { getOrgConfig, getHierarchyLevel, getUserPermissions } from '@/lib/org-config';
+import { LogOut, Building2, ChevronDown, BarChart3, LineChart as LineChartIcon, Users as UsersIcon, Activity, ClipboardList, TrendingUp, TrendingDown, Minus, LayoutGrid, List, Info, CheckCircle, Download } from 'lucide-react';
+import * as XLSX from 'xlsx';
 import { AlertCircle } from 'lucide-react';
 import { getTeamSubmissionStatus, getAssessmentPeriods, TeamSubmissionStatus } from '@/lib/api/health-checks';
 import { API_BASE_URL } from '@/lib/api/client';
@@ -358,6 +359,7 @@ export default function DashboardPage() {
 
   const config = getOrgConfig();
   const userLevel = getHierarchyLevel(user.hierarchyLevelId || '');
+  const userPermissions = getUserPermissions(user);
 
   // Get score color
   const getScoreColor = (score: number) => {
@@ -382,6 +384,61 @@ export default function DashboardPage() {
       : avg >= 1.5
       ? { backgroundColor: '#FEF3C7', color: '#92400E' }
       : { backgroundColor: '#FEE2E2', color: '#991B1B' };
+
+  const getScoreBandLabel = (avg: number): string => {
+    if (avg >= 2.7) return 'Excellent';
+    if (avg >= 2.3) return 'Good';
+    if (avg >= 1.7) return 'Fair';
+    return 'Poor';
+  };
+
+  const handleExportToExcel = () => {
+    const teamName = teamOptions.find(t => t.id === teamId)?.name || teamId;
+    const periodLabel = selectedPeriod || 'All Periods';
+
+    // Sheet 1: Summary — dimension averages with band labels
+    const summaryRows = healthSummary.map(h => ({
+      Dimension: h.dimension,
+      'Average Score': parseFloat(h.averageScore.toFixed(2)),
+      Band: getScoreBandLabel(h.averageScore),
+    }));
+    const summarySheet = XLSX.utils.json_to_sheet(summaryRows);
+
+    // Sheet 2: Individual responses — one row per member per dimension
+    const responseRows = individualResponses.flatMap(r =>
+      r.responses.map(resp => ({
+        Member: r.userName,
+        'Survey Type': r.surveyType === 'post_workshop' ? 'Post-Workshop' : 'Individual',
+        Date: new Date(r.date).toLocaleDateString(),
+        Dimension: resp.dimensionName,
+        Score: resp.score,
+        'Score Label': resp.score === 3 ? 'Green' : resp.score === 2 ? 'Yellow' : 'Red',
+        Trend: resp.trend || '',
+        Comment: resp.comment || '',
+      }))
+    );
+    const responsesSheet = XLSX.utils.json_to_sheet(responseRows);
+
+    // Sheet 3: Distribution
+    const distributionRows = breakdownData.map(d => ({
+      Dimension: d.dimension,
+      Green: d.green,
+      Yellow: d.yellow,
+      Red: d.red,
+      Total: d.total,
+      'Health Score': parseFloat(d.healthScore.toFixed(2)),
+      Band: getScoreBandLabel(d.healthScore),
+    }));
+    const distributionSheet = XLSX.utils.json_to_sheet(distributionRows);
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, summarySheet, 'Summary');
+    XLSX.utils.book_append_sheet(wb, responsesSheet, 'Individual Responses');
+    XLSX.utils.book_append_sheet(wb, distributionSheet, 'Distribution');
+
+    const fileName = `health-check-${teamName.replace(/\s+/g, '-').toLowerCase()}-${periodLabel.replace(/\s+/g, '-').toLowerCase()}.xlsx`;
+    XLSX.writeFile(wb, fileName);
+  };
 
   const getShortDimName = (name: string) => {
     const map: Record<string, string> = {
@@ -503,10 +560,10 @@ export default function DashboardPage() {
       </div>
 
       <div className="container mx-auto px-4 py-8">
-        {/* Assessment Period Filter */}
+        {/* Assessment Period Filter + Export */}
         <div className="mb-6 flex justify-between items-center">
           <h2 className="text-xl font-semibold text-gray-900">Team Health Overview</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <label htmlFor="period-filter" className="text-sm text-gray-600">
               Assessment Period:
             </label>
@@ -522,6 +579,16 @@ export default function DashboardPage() {
                 <option key={period} value={period}>{period}</option>
               ))}
             </select>
+            {userPermissions.canExportData && individualResponses.length > 0 && (
+              <button
+                data-testid="export-excel-btn"
+                onClick={handleExportToExcel}
+                className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm font-medium"
+              >
+                <Download className="w-4 h-4" />
+                Export to Excel
+              </button>
+            )}
           </div>
         </div>
 
@@ -599,7 +666,15 @@ export default function DashboardPage() {
                 {/* Radar Chart Tab */}
                 {activeTab === 'radar' && (
                   <div data-testid="radar-chart-section">
-                    <h2 className="text-xl font-semibold text-gray-900 mb-6">Team Health Overview</h2>
+                    <h2 className="text-xl font-semibold text-gray-900 mb-4">Team Health Overview</h2>
+                    {/* Score Band Legend */}
+                    <div data-testid="score-band-legend" className="flex flex-wrap items-center gap-3 mb-6 p-3 bg-gray-50 rounded-lg border border-gray-200 text-xs font-medium">
+                      <span className="text-gray-500 font-semibold">Score bands:</span>
+                      <span className="px-2.5 py-1 rounded-full bg-emerald-100 text-emerald-800">2.7 – 3.0 Excellent</span>
+                      <span className="px-2.5 py-1 rounded-full bg-green-100 text-green-800">2.3 – 2.6 Good</span>
+                      <span className="px-2.5 py-1 rounded-full bg-yellow-100 text-yellow-800">1.7 – 2.2 Fair</span>
+                      <span className="px-2.5 py-1 rounded-full bg-red-100 text-red-800">1.0 – 1.6 Poor</span>
+                    </div>
                     {healthSummary.length > 0 ? (
                       <div data-testid="radar-chart" style={{ width: '100%', height: 500 }}>
                       <ResponsiveContainer width="100%" height={500}>
@@ -708,8 +783,9 @@ export default function DashboardPage() {
                                   )}
                                 </div>
                                 <span
-                                  className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold w-12 text-center flex-shrink-0"
+                                  className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold text-center flex-shrink-0"
                                   style={getAvgBadgeStyle(d.healthScore)}
+                                  title={getScoreBandLabel(d.healthScore)}
                                 >
                                   {d.healthScore.toFixed(1)}
                                 </span>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -579,7 +579,7 @@ export default function DashboardPage() {
                 <option key={period} value={period}>{period}</option>
               ))}
             </select>
-            {userPermissions.canExportData && healthSummary.length > 0 && (
+            {(userPermissions.canExportData || userPermissions.canViewReports) && healthSummary.length > 0 && (
               <button
                 data-testid="export-excel-btn"
                 onClick={handleExportToExcel}

--- a/frontend/app/manager/page.tsx
+++ b/frontend/app/manager/page.tsx
@@ -6,8 +6,9 @@ import { getCurrentUser, logout, authenticatedFetch, User } from '@/lib/auth';
 import { HEALTH_DIMENSIONS } from '@/lib/data';
 import { API_BASE_URL } from '@/lib/api/client';
 import { getAssessmentPeriods } from '@/lib/api/health-checks';
-import { LogOut, Users, ChevronDown, AlertCircle, Activity, LineChart as LineChartIcon, CheckCircle, Clock, ClipboardList, TrendingUp, TrendingDown, Minus, LayoutGrid } from 'lucide-react';
+import { LogOut, Users, ChevronDown, AlertCircle, Activity, LineChart as LineChartIcon, CheckCircle, Clock, ClipboardList, TrendingUp, TrendingDown, Minus, LayoutGrid, Download } from 'lucide-react';
 import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import * as XLSX from 'xlsx';
 
 // Types matching backend API response
 interface DimensionSummary {
@@ -335,6 +336,49 @@ export default function ManagerPage() {
       ? { backgroundColor: '#FEF3C7', color: '#92400E' }
       : { backgroundColor: '#FEE2E2', color: '#991B1B' };
 
+  const getScoreBandLabel = (avg: number): string => {
+    if (avg >= 2.7) return 'Excellent';
+    if (avg >= 2.3) return 'Good';
+    if (avg >= 1.7) return 'Fair';
+    return 'Poor';
+  };
+
+  const handleExportToExcel = () => {
+    if (!dashboardData) return;
+    const periodLabel = selectedPeriod || 'All Periods';
+
+    // Sheet 1: Team summary
+    const teamRows = dashboardData.teams.map(t => ({
+      Team: t.teamName,
+      'Overall Health Score': parseFloat(t.overallHealth.toFixed(2)),
+      Band: getScoreBandLabel(t.overallHealth),
+      'Submission Count': t.submissionCount,
+    }));
+    const teamsSheet = XLSX.utils.json_to_sheet(teamRows);
+
+    // Sheet 2: Per-team dimension breakdown
+    const dimensionRows = dashboardData.teams.flatMap(t =>
+      t.dimensions.map(d => {
+        const dimInfo = HEALTH_DIMENSIONS.find(hd => hd.id === d.dimensionId);
+        return {
+          Team: t.teamName,
+          Dimension: dimInfo?.name || d.dimensionId,
+          'Average Score': parseFloat(d.avgScore.toFixed(2)),
+          Band: getScoreBandLabel(d.avgScore),
+          'Response Count': d.responseCount,
+        };
+      })
+    );
+    const dimensionsSheet = XLSX.utils.json_to_sheet(dimensionRows);
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, teamsSheet, 'Team Summary');
+    XLSX.utils.book_append_sheet(wb, dimensionsSheet, 'Dimension Breakdown');
+
+    const fileName = `health-check-manager-${periodLabel.replace(/\s+/g, '-').toLowerCase()}.xlsx`;
+    XLSX.writeFile(wb, fileName);
+  };
+
   const dimSparklines = HEALTH_DIMENSIONS.map((dim) => {
     const data = trendsData.map((t) => ({
       period: t.period as string,
@@ -398,10 +442,10 @@ export default function ManagerPage() {
       </div>
 
       <div className="container mx-auto px-4 py-8">
-        {/* Assessment Period Filter */}
-        <div className="mb-6 flex justify-between items-center">
+        {/* Assessment Period Filter + Score Band Legend + Export */}
+        <div className="mb-4 flex justify-between items-center">
           <h2 className="text-xl font-semibold text-gray-900">Team Health Overview</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <label htmlFor="period-filter" className="text-sm text-gray-600">
               Assessment Period:
             </label>
@@ -417,7 +461,26 @@ export default function ManagerPage() {
                 <option key={period} value={period}>{period}</option>
               ))}
             </select>
+            {dashboardData && dashboardData.teams.length > 0 && (
+              <button
+                data-testid="export-excel-btn"
+                onClick={handleExportToExcel}
+                className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm font-medium"
+              >
+                <Download className="w-4 h-4" />
+                Export to Excel
+              </button>
+            )}
           </div>
+        </div>
+
+        {/* Score Band Legend */}
+        <div data-testid="score-band-legend" className="mb-6 flex flex-wrap items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200 text-xs font-medium">
+          <span className="text-gray-500 font-semibold">Score bands:</span>
+          <span className="px-2.5 py-1 rounded-full bg-emerald-100 text-emerald-800">2.7 – 3.0 Excellent</span>
+          <span className="px-2.5 py-1 rounded-full bg-green-100 text-green-800">2.3 – 2.6 Good</span>
+          <span className="px-2.5 py-1 rounded-full bg-yellow-100 text-yellow-800">1.7 – 2.2 Fair</span>
+          <span className="px-2.5 py-1 rounded-full bg-red-100 text-red-800">1.0 – 1.6 Poor</span>
         </div>
 
         {/* Tab Navigation */}

--- a/frontend/app/survey/page.tsx
+++ b/frontend/app/survey/page.tsx
@@ -258,7 +258,7 @@ function SurveyPageContent() {
       return;
     }
 
-    if (!isTeamMember && !currentResponse?.trend) {
+    if ((!isTeamMember || isPostWorkshop) && !currentResponse?.trend) {
       setValidationError('Please select a trend (Improving, Stable, or Declining) before continuing.');
       return;
     }
@@ -288,7 +288,7 @@ function SurveyPageContent() {
     }
 
     // Validate each response has both score and trend (trend only required for non-team-members)
-    const incompleteResponses = responses.filter(r => !r.score || (!isTeamMember && !r.trend));
+    const incompleteResponses = responses.filter(r => !r.score || ((!isTeamMember || isPostWorkshop) && !r.trend));
     if (incompleteResponses.length > 0) {
       setValidationError(isTeamMember
         ? 'Please select a score for all dimensions before submitting.'
@@ -559,7 +559,7 @@ function SurveyPageContent() {
 
             {currentResponse?.score && (
               <div className="mb-8 p-6 bg-gray-50 rounded-xl">
-                {!isTeamMember && (
+                {(!isTeamMember || isPostWorkshop) && (
                   <>
                     <h3 className="font-semibold text-gray-900 mb-4">Trend</h3>
                     <div className="flex gap-4">

--- a/frontend/app/survey/page.tsx
+++ b/frontend/app/survey/page.tsx
@@ -258,7 +258,7 @@ function SurveyPageContent() {
       return;
     }
 
-    if (!currentResponse?.trend) {
+    if (!isTeamMember && !currentResponse?.trend) {
       setValidationError('Please select a trend (Improving, Stable, or Declining) before continuing.');
       return;
     }
@@ -287,10 +287,13 @@ function SurveyPageContent() {
       return;
     }
 
-    // Validate each response has both score and trend
-    const incompleteResponses = responses.filter(r => !r.score || !r.trend);
+    // Validate each response has both score and trend (trend only required for non-team-members)
+    const incompleteResponses = responses.filter(r => !r.score || (!isTeamMember && !r.trend));
     if (incompleteResponses.length > 0) {
-      setValidationError('Please select both a score and trend for all dimensions before submitting.');
+      setValidationError(isTeamMember
+        ? 'Please select a score for all dimensions before submitting.'
+        : 'Please select both a score and trend for all dimensions before submitting.'
+      );
       return;
     }
 
@@ -411,6 +414,7 @@ function SurveyPageContent() {
   const currentResponse = getCurrentResponse();
 
   const isTeamLead = user.hierarchyLevelId === 'level-4';
+  const isTeamMember = user.hierarchyLevelId === 'level-5';
 
   // Compute display period from team cadence
   const surveyPeriod = team ? getAssessmentPeriod(new Date(), toCadence(team.cadence)) : '';
@@ -555,50 +559,54 @@ function SurveyPageContent() {
 
             {currentResponse?.score && (
               <div className="mb-8 p-6 bg-gray-50 rounded-xl">
-                <h3 className="font-semibold text-gray-900 mb-4">Trend</h3>
-                <div className="flex gap-4">
-                  <button
-                    onClick={() => handleTrendSelect('improving')}
-                    data-dimension={dimension.id}
-                    data-trend="improving"
-                    className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
-                      currentResponse?.trend === 'improving'
-                        ? 'border-green-500 bg-green-50 text-green-700'
-                        : 'border-gray-300 bg-white text-gray-700 hover:border-green-300 hover:bg-green-50'
-                    }`}
-                  >
-                    <TrendingUp className="w-5 h-5" />
-                    Improving
-                  </button>
-                  <button
-                    onClick={() => handleTrendSelect('stable')}
-                    data-dimension={dimension.id}
-                    data-trend="stable"
-                    className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
-                      currentResponse?.trend === 'stable'
-                        ? 'border-blue-500 bg-blue-50 text-blue-700'
-                        : 'border-gray-300 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
-                    }`}
-                  >
-                    <Minus className="w-5 h-5" />
-                    Stable
-                  </button>
-                  <button
-                    onClick={() => handleTrendSelect('declining')}
-                    data-dimension={dimension.id}
-                    data-trend="declining"
-                    className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
-                      currentResponse?.trend === 'declining'
-                        ? 'border-red-500 bg-red-50 text-red-700'
-                        : 'border-gray-300 bg-white text-gray-700 hover:border-red-300 hover:bg-red-50'
-                    }`}
-                  >
-                    <TrendingDown className="w-5 h-5" />
-                    Declining
-                  </button>
-                </div>
+                {!isTeamMember && (
+                  <>
+                    <h3 className="font-semibold text-gray-900 mb-4">Trend</h3>
+                    <div className="flex gap-4">
+                      <button
+                        onClick={() => handleTrendSelect('improving')}
+                        data-dimension={dimension.id}
+                        data-trend="improving"
+                        className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
+                          currentResponse?.trend === 'improving'
+                            ? 'border-green-500 bg-green-50 text-green-700'
+                            : 'border-gray-300 bg-white text-gray-700 hover:border-green-300 hover:bg-green-50'
+                        }`}
+                      >
+                        <TrendingUp className="w-5 h-5" />
+                        Improving
+                      </button>
+                      <button
+                        onClick={() => handleTrendSelect('stable')}
+                        data-dimension={dimension.id}
+                        data-trend="stable"
+                        className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
+                          currentResponse?.trend === 'stable'
+                            ? 'border-blue-500 bg-blue-50 text-blue-700'
+                            : 'border-gray-300 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
+                        }`}
+                      >
+                        <Minus className="w-5 h-5" />
+                        Stable
+                      </button>
+                      <button
+                        onClick={() => handleTrendSelect('declining')}
+                        data-dimension={dimension.id}
+                        data-trend="declining"
+                        className={`flex-1 p-3 rounded-lg border-2 flex items-center justify-center gap-2 transition-all ${
+                          currentResponse?.trend === 'declining'
+                            ? 'border-red-500 bg-red-50 text-red-700'
+                            : 'border-gray-300 bg-white text-gray-700 hover:border-red-300 hover:bg-red-50'
+                        }`}
+                      >
+                        <TrendingDown className="w-5 h-5" />
+                        Declining
+                      </button>
+                    </div>
+                  </>
+                )}
 
-                <div className="mt-4">
+                <div className={!isTeamMember ? 'mt-4' : ''}>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     Comments (optional)
                   </label>

--- a/frontend/app/survey/page.tsx
+++ b/frontend/app/survey/page.tsx
@@ -290,9 +290,9 @@ function SurveyPageContent() {
     // Validate each response has both score and trend (trend only required for non-team-members)
     const incompleteResponses = responses.filter(r => !r.score || ((!isTeamMember || isPostWorkshop) && !r.trend));
     if (incompleteResponses.length > 0) {
-      setValidationError(isTeamMember
-        ? 'Please select a score for all dimensions before submitting.'
-        : 'Please select both a score and trend for all dimensions before submitting.'
+      setValidationError((!isTeamMember || isPostWorkshop)
+        ? 'Please select both a score and trend for all dimensions before submitting.'
+        : 'Please select a score for all dimensions before submitting.'
       );
       return;
     }

--- a/frontend/lib/org-config.ts
+++ b/frontend/lib/org-config.ts
@@ -58,7 +58,7 @@ export const DEFAULT_ORG_CONFIG: OrganizationConfig = {
         canManageUsers: false,
         canConfigureSystem: false,
         canViewReports: true,
-        canExportData: false
+        canExportData: true
       }
     },
     {
@@ -84,15 +84,24 @@ export const DEFAULT_ORG_CONFIG: OrganizationConfig = {
 // Store organization config (in production, this would be in a database)
 let currentConfig: OrganizationConfig = DEFAULT_ORG_CONFIG;
 
+// Increment this when DEFAULT_ORG_CONFIG changes (e.g. permission updates) to
+// force-replace stale localStorage copies.
+const ORG_CONFIG_VERSION = 2;
+
 // Initialize from localStorage if available
 if (typeof window !== 'undefined') {
   const stored = localStorage.getItem('orgConfig');
-  if (stored) {
+  const storedVersion = parseInt(localStorage.getItem('orgConfigVersion') || '0', 10);
+  if (stored && storedVersion >= ORG_CONFIG_VERSION) {
     try {
       currentConfig = JSON.parse(stored);
     } catch (e) {
       console.error('Failed to load org config:', e);
     }
+  } else {
+    // Stale or missing version — reset to updated defaults
+    localStorage.removeItem('orgConfig');
+    localStorage.setItem('orgConfigVersion', String(ORG_CONFIG_VERSION));
   }
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "react-dom": "19.1.0",
         "react-hook-form": "^7.63.0",
         "recharts": "^3.2.1",
-        "web-vitals": "^4.2.4"
+        "web-vitals": "^4.2.4",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -3814,6 +3815,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4347,6 +4357,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -4447,6 +4470,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4487,6 +4519,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5929,6 +5973,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -8761,6 +8814,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -10039,6 +10104,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10167,6 +10250,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.63.0",
     "recharts": "^3.2.1",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^4.2.4",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/tests/acceptance/e2e_cadence_period_test.go
+++ b/tests/acceptance/e2e_cadence_period_test.go
@@ -111,7 +111,9 @@ var _ = Describe("E2E: Cadence-Driven Assessment Periods", Label("e2e"), func() 
 				}, 10*time.Second, 500*time.Millisecond).Should(ContainSubstring("Quarterly Check"))
 
 				By("Filling all 11 dimensions and submitting")
-				fillDimension := func(dimensionID string, score int, trend string) {
+				// Note: e2e_demo is a Team Member (level-5) — trend input is hidden for individual surveys.
+				// Only score selection is needed.
+				fillDimension := func(dimensionID string, score int) {
 					scoreSelector := fmt.Sprintf("[data-dimension='%s'][data-score='%d']", dimensionID, score)
 					err = page.Locator(scoreSelector).WaitFor(playwright.LocatorWaitForOptions{
 						State:   playwright.WaitForSelectorStateVisible,
@@ -119,16 +121,6 @@ var _ = Describe("E2E: Cadence-Driven Assessment Periods", Label("e2e"), func() 
 					})
 					Expect(err).NotTo(HaveOccurred())
 					err = page.Locator(scoreSelector).Click()
-					Expect(err).NotTo(HaveOccurred())
-					time.Sleep(500 * time.Millisecond)
-
-					trendSelector := fmt.Sprintf("[data-dimension='%s'][data-trend='%s']", dimensionID, trend)
-					err = page.Locator(trendSelector).WaitFor(playwright.LocatorWaitForOptions{
-						State:   playwright.WaitForSelectorStateVisible,
-						Timeout: playwright.Float(5000),
-					})
-					Expect(err).NotTo(HaveOccurred())
-					err = page.Locator(trendSelector).Click()
 					Expect(err).NotTo(HaveOccurred())
 					time.Sleep(500 * time.Millisecond)
 				}
@@ -152,10 +144,10 @@ var _ = Describe("E2E: Cadence-Driven Assessment Periods", Label("e2e"), func() 
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				// Fill all 11 dimensions: score Green (3), trend stable
+				// Fill all 11 dimensions: score Green (3)
 				dimensions := []string{"mission", "value", "speed", "fun", "health", "learning", "support", "pawns", "release", "process", "teamwork"}
 				for i, dim := range dimensions {
-					fillDimension(dim, 3, "stable")
+					fillDimension(dim, 3)
 					if i < len(dimensions)-1 {
 						clickNext()
 					}
@@ -272,6 +264,8 @@ var _ = Describe("E2E: Cadence-Driven Assessment Periods", Label("e2e"), func() 
 				}, 10*time.Second, 500*time.Millisecond).Should(ContainSubstring("Monthly Check"))
 
 				By("Filling all 11 dimensions and submitting")
+				// Note: e2e_demo is a Team Member (level-5) — trend input is hidden for individual surveys.
+				// Only score selection is needed.
 				err = page.Locator("text=Mission").WaitFor(playwright.LocatorWaitForOptions{
 					State:   playwright.WaitForSelectorStateVisible,
 					Timeout: playwright.Float(10000),
@@ -287,16 +281,6 @@ var _ = Describe("E2E: Cadence-Driven Assessment Periods", Label("e2e"), func() 
 					})
 					Expect(err).NotTo(HaveOccurred())
 					err = page.Locator(scoreSelector).Click()
-					Expect(err).NotTo(HaveOccurred())
-					time.Sleep(500 * time.Millisecond)
-
-					trendSelector := fmt.Sprintf("[data-dimension='%s'][data-trend='stable']", dim)
-					err = page.Locator(trendSelector).WaitFor(playwright.LocatorWaitForOptions{
-						State:   playwright.WaitForSelectorStateVisible,
-						Timeout: playwright.Float(5000),
-					})
-					Expect(err).NotTo(HaveOccurred())
-					err = page.Locator(trendSelector).Click()
 					Expect(err).NotTo(HaveOccurred())
 					time.Sleep(500 * time.Millisecond)
 

--- a/tests/acceptance/e2e_complete_flow_test.go
+++ b/tests/acceptance/e2e_complete_flow_test.go
@@ -145,17 +145,9 @@ var _ = Describe("E2E: Complete Data Flow", Label("e2e", "critical"), func() {
 					err = scoreBtn.Click()
 					Expect(err).NotTo(HaveOccurred())
 
-					// Wait for trend buttons to appear (they only show after score is selected)
+					// Note: testMemberID (e2e_demo) is a Team Member (level-5) — trend input is hidden
+					// for individual surveys. Only score selection is needed.
 					time.Sleep(300 * time.Millisecond)
-
-					// Select trend using data-trend attribute (stable for simplicity)
-					trendBtn := page.Locator("button[data-trend='stable']").First()
-					Eventually(func() bool {
-						visible, _ := trendBtn.IsVisible()
-						return visible
-					}, 5*time.Second, 200*time.Millisecond).Should(BeTrue(), "Trend button should be visible")
-					err = trendBtn.Click()
-					Expect(err).NotTo(HaveOccurred())
 
 					// Add comment on first dimension only
 					if i == 0 {

--- a/tests/acceptance/e2e_survey_autosave_test.go
+++ b/tests/acceptance/e2e_survey_autosave_test.go
@@ -24,7 +24,7 @@ var _ = Describe("E2E: Survey Autosave", Label("e2e"), func() {
 		page, err = ctx.NewPage()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Clear any existing draft for e2e_demo user before each test
+		// Clear any existing draft before each test
 		_, err = page.Goto(frontendURL + "/login")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = page.Evaluate(`() => {
@@ -49,7 +49,7 @@ var _ = Describe("E2E: Survey Autosave", Label("e2e"), func() {
 	})
 
 	loginAndGoToSurvey := func() {
-		By("Logging in as e2e_demo")
+		By("Logging in as e2e_lead1 (Team Lead, level-4)")
 		_, err := page.Goto(frontendURL + "/login")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -59,27 +59,21 @@ var _ = Describe("E2E: Survey Autosave", Label("e2e"), func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = page.Locator("input[name='username']").Fill("e2e_demo")
+		err = page.Locator("input[name='username']").Fill("e2e_lead1")
 		Expect(err).NotTo(HaveOccurred())
 		err = page.Locator("input[name='password']").Fill("demo")
 		Expect(err).NotTo(HaveOccurred())
 		err = page.Locator("button[type='submit']").Click()
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for redirect to home page")
-		err = page.WaitForURL("**/home", playwright.PageWaitForURLOptions{
+		By("Waiting for redirect to dashboard page")
+		err = page.WaitForURL("**/dashboard", playwright.PageWaitForURLOptions{
 			Timeout: playwright.Float(10000),
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Navigating to survey")
-		surveyBtn := page.Locator("[data-testid='take-survey-btn']")
-		err = surveyBtn.WaitFor(playwright.LocatorWaitForOptions{
-			State:   playwright.WaitForSelectorStateVisible,
-			Timeout: playwright.Float(5000),
-		})
-		Expect(err).NotTo(HaveOccurred())
-		err = surveyBtn.Click()
+		_, err = page.Goto(frontendURL + "/survey")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = page.WaitForURL("**/survey", playwright.PageWaitForURLOptions{

--- a/tests/acceptance/e2e_survey_autosave_test.go
+++ b/tests/acceptance/e2e_survey_autosave_test.go
@@ -46,6 +46,14 @@ var _ = Describe("E2E: Survey Autosave", Label("e2e"), func() {
 		if ctx != nil {
 			ctx.Close()
 		}
+		// Clean up any sessions submitted by e2e_lead1 during autosave tests to avoid
+		// polluting the team lead dashboard tests with unexpected current-period data.
+		db.Exec(`DELETE FROM health_check_responses WHERE session_id IN (
+			SELECT id FROM health_check_sessions WHERE user_id = 'e2e_lead1'
+			AND id NOT LIKE 'e2e_%' AND id NOT LIKE 'demo-%'
+		)`)
+		db.Exec(`DELETE FROM health_check_sessions WHERE user_id = 'e2e_lead1'
+			AND id NOT LIKE 'e2e_%' AND id NOT LIKE 'demo-%'`)
 	})
 
 	loginAndGoToSurvey := func() {

--- a/tests/acceptance/e2e_survey_submission_test.go
+++ b/tests/acceptance/e2e_survey_submission_test.go
@@ -340,6 +340,74 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 		})
 	})
 
+	Describe("Trend input visibility", func() {
+		Context("when a Team Member (level-5) loads the survey", func() {
+			It("should not show trend buttons for any dimension", func() {
+				By("Opening browser and logging in as Team Member")
+				page, err := browser.NewPage()
+				Expect(err).NotTo(HaveOccurred())
+				defer page.Close()
+
+				_, err = page.Goto(frontendURL + "/login")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.Locator("#username").Fill("e2e_demo")
+				Expect(err).NotTo(HaveOccurred())
+				err = page.Locator("#password").Fill("demo")
+				Expect(err).NotTo(HaveOccurred())
+				err = page.Locator("button[type='submit']:has-text('Sign In')").Click()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.WaitForURL("**/home", playwright.PageWaitForURLOptions{
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				surveyBtn := page.Locator("[data-testid='take-survey-btn']")
+				err = surveyBtn.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				err = surveyBtn.Click()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.WaitForURL("**/survey", playwright.PageWaitForURLOptions{
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for survey to load")
+				err = page.Locator("text=Mission").WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(10000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Selecting a score to trigger the post-score section")
+				err = page.Locator("[data-dimension='mission'][data-score='3']").Click()
+				Expect(err).NotTo(HaveOccurred())
+				time.Sleep(500 * time.Millisecond)
+
+				By("Verifying trend buttons are NOT visible for Team Member")
+				improvingBtn := page.Locator("[data-dimension='mission'][data-trend='improving']")
+				visible, err := improvingBtn.IsVisible()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(visible).To(BeFalse(), "Trend buttons should not be shown for Team Members")
+
+				By("Verifying comment textarea IS still visible")
+				commentBox := page.Locator("[data-dimension='mission']").Filter(playwright.LocatorFilterOptions{
+					Has: page.Locator("textarea"),
+				})
+				commentVisible, err := commentBox.IsVisible()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(commentVisible).To(BeTrue(), "Comment box should still be visible for Team Members")
+
+				GinkgoWriter.Printf("Trend buttons correctly hidden for Team Member\n")
+			})
+		})
+	})
+
 	Describe("Error handling and validation", func() {
 		Context("when submitting incomplete survey", func() {
 			It("should show validation errors and prevent submission", func() {

--- a/tests/acceptance/e2e_survey_submission_test.go
+++ b/tests/acceptance/e2e_survey_submission_test.go
@@ -125,7 +125,9 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 			By("Selecting health check responses for all 11 dimensions (paginated survey)")
 
 			// Helper function to fill a dimension
-			fillDimension := func(dimensionID string, score int, trend string) {
+			// Note: e2e_demo is a Team Member (level-5) so trend input is hidden for individual surveys.
+			// Only score is required for Team Members; trend argument is accepted but ignored.
+			fillDimension := func(dimensionID string, score int, _ string) {
 				scoreSelector := fmt.Sprintf("[data-dimension='%s'][data-score='%d']", dimensionID, score)
 				err = page.Locator(scoreSelector).WaitFor(playwright.LocatorWaitForOptions{
 					State:   playwright.WaitForSelectorStateVisible,
@@ -134,17 +136,7 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = page.Locator(scoreSelector).Click()
 				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(500 * time.Millisecond) // Increased wait for React state update
-
-				trendSelector := fmt.Sprintf("[data-dimension='%s'][data-trend='%s']", dimensionID, trend)
-				err = page.Locator(trendSelector).WaitFor(playwright.LocatorWaitForOptions{
-					State:   playwright.WaitForSelectorStateVisible,
-					Timeout: playwright.Float(5000), // Increased timeout
-				})
-				Expect(err).NotTo(HaveOccurred())
-				err = page.Locator(trendSelector).Click()
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(500 * time.Millisecond) // Increased wait for React state update
+				time.Sleep(500 * time.Millisecond) // Wait for React state update
 			}
 
 			clickNext := func() {
@@ -257,32 +249,31 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 			Expect(responseCount).To(Equal(11), "Should have 11 dimension responses")
 
 			By("Verifying specific response data")
-			// Check Mission response
-			var dimensionID, trend, comment string
+			// Note: e2e_demo is a Team Member (level-5) — trend input is hidden for individual surveys,
+			// so only score is verified here.
+			var dimensionID, comment string
 			var score int
 
 			err = db.QueryRow(`
-				SELECT dimension_id, score, trend, comment
+				SELECT dimension_id, score, comment
 				FROM health_check_responses
 				WHERE session_id = $1 AND dimension_id = 'mission'
-			`, sessionID).Scan(&dimensionID, &score, &trend, &comment)
+			`, sessionID).Scan(&dimensionID, &score, &comment)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dimensionID).To(Equal("mission"))
 			Expect(score).To(Equal(3))
-			Expect(trend).To(Equal("improving"))
 
-			// Check Speed response (Red, Declining)
+			// Check Speed response (Red)
 			err = db.QueryRow(`
-				SELECT dimension_id, score, trend
+				SELECT dimension_id, score
 				FROM health_check_responses
 				WHERE session_id = $1 AND dimension_id = 'speed'
-			`, sessionID).Scan(&dimensionID, &score, &trend)
+			`, sessionID).Scan(&dimensionID, &score)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dimensionID).To(Equal("speed"))
 			Expect(score).To(Equal(1))
-			Expect(trend).To(Equal("declining"))
 
 			By("Verifying assessment period was auto-calculated")
 			Expect(assessmentPeriod).NotTo(BeEmpty())

--- a/tests/acceptance/e2e_survey_submission_test.go
+++ b/tests/acceptance/e2e_survey_submission_test.go
@@ -387,9 +387,7 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 				Expect(visible).To(BeFalse(), "Trend buttons should not be shown for Team Members on individual survey")
 
 				By("Verifying comment textarea IS still visible")
-				commentBox := page.Locator("[data-dimension='mission']").Filter(playwright.LocatorFilterOptions{
-					Has: page.Locator("textarea"),
-				})
+				commentBox := page.Locator("textarea[data-dimension='mission']")
 				commentVisible, err := commentBox.IsVisible()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(commentVisible).To(BeTrue(), "Comment box should still be visible for Team Members")

--- a/tests/acceptance/e2e_survey_submission_test.go
+++ b/tests/acceptance/e2e_survey_submission_test.go
@@ -389,11 +389,11 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(500 * time.Millisecond)
 
-				By("Verifying trend buttons are NOT visible for Team Member")
+				By("Verifying trend buttons are NOT visible for Team Member on individual survey")
 				improvingBtn := page.Locator("[data-dimension='mission'][data-trend='improving']")
 				visible, err := improvingBtn.IsVisible()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(visible).To(BeFalse(), "Trend buttons should not be shown for Team Members")
+				Expect(visible).To(BeFalse(), "Trend buttons should not be shown for Team Members on individual survey")
 
 				By("Verifying comment textarea IS still visible")
 				commentBox := page.Locator("[data-dimension='mission']").Filter(playwright.LocatorFilterOptions{
@@ -403,7 +403,62 @@ var _ = Describe("E2E: Survey Submission Flow", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(commentVisible).To(BeTrue(), "Comment box should still be visible for Team Members")
 
-				GinkgoWriter.Printf("Trend buttons correctly hidden for Team Member\n")
+				GinkgoWriter.Printf("Trend buttons correctly hidden for Team Member on individual survey\n")
+			})
+		})
+
+		Context("when a Team Member loads the post-workshop survey", func() {
+			It("should show trend buttons on post-workshop survey regardless of role", func() {
+				By("Opening browser and logging in as Team Member")
+				page, err := browser.NewPage()
+				Expect(err).NotTo(HaveOccurred())
+				defer page.Close()
+
+				_, err = page.Goto(frontendURL + "/login")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.Locator("#username").Fill("e2e_demo")
+				Expect(err).NotTo(HaveOccurred())
+				err = page.Locator("#password").Fill("demo")
+				Expect(err).NotTo(HaveOccurred())
+				err = page.Locator("button[type='submit']:has-text('Sign In')").Click()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.WaitForURL("**/home", playwright.PageWaitForURLOptions{
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Navigating directly to post-workshop survey")
+				_, err = page.Goto(frontendURL + "/survey?type=post_workshop")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = page.WaitForURL("**/survey**", playwright.PageWaitForURLOptions{
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for survey to load")
+				err = page.Locator("text=Mission").WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(10000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Selecting a score to trigger the post-score section")
+				err = page.Locator("[data-dimension='mission'][data-score='3']").Click()
+				Expect(err).NotTo(HaveOccurred())
+				time.Sleep(500 * time.Millisecond)
+
+				By("Verifying trend buttons ARE visible on post-workshop survey")
+				improvingBtn := page.Locator("[data-dimension='mission'][data-trend='improving']")
+				err = improvingBtn.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(5000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				GinkgoWriter.Printf("Trend buttons correctly shown on post-workshop survey\n")
 			})
 		})
 	})

--- a/tests/acceptance/e2e_team_lead_dashboard_test.go
+++ b/tests/acceptance/e2e_team_lead_dashboard_test.go
@@ -364,6 +364,90 @@ var _ = Describe("E2E: Team Lead Dashboard", func() {
 		})
 	})
 
+	Describe("Score Band Legend", func() {
+		Context("when Team Lead views the radar chart tab", func() {
+			It("should display the score band legend", func() {
+				page, err := browser.NewPage()
+				Expect(err).NotTo(HaveOccurred())
+				defer page.Close()
+
+				By("Logging in as Team Lead")
+				loginAsTeamLead(page)
+
+				By("Verifying score band legend is visible on radar tab")
+				legend := page.Locator("[data-testid='score-band-legend']")
+				err = legend.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(15000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying all four bands are shown")
+				legendText, err := legend.InnerText()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(legendText).To(ContainSubstring("Excellent"))
+				Expect(legendText).To(ContainSubstring("Good"))
+				Expect(legendText).To(ContainSubstring("Fair"))
+				Expect(legendText).To(ContainSubstring("Poor"))
+
+				GinkgoWriter.Printf("Score band legend displayed successfully\n")
+			})
+		})
+	})
+
+	Describe("Export to Excel", func() {
+		Context("when Team Lead has data and clicks export", func() {
+			It("should show the export button when individual responses are loaded", func() {
+				page, err := browser.NewPage()
+				Expect(err).NotTo(HaveOccurred())
+				defer page.Close()
+
+				By("Logging in as Team Lead")
+				loginAsTeamLead(page)
+
+				By("Waiting for data to load on dashboard")
+				radarSection := page.Locator("[data-testid='radar-chart-section']")
+				err = radarSection.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(15000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Clicking Individual Responses tab to load data for export")
+				responsesTab := page.Locator("[data-testid='responses-tab']")
+				err = responsesTab.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(10000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				err = responsesTab.Click()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for response cards to load")
+				Eventually(func() bool {
+					cards := page.Locator("[data-testid='response-card']")
+					count, _ := cards.Count()
+					return count > 0
+				}, 15*time.Second, 500*time.Millisecond).Should(BeTrue(), "Response cards should load")
+
+				By("Going back to radar tab where export button is shown")
+				radarTab := page.Locator("[data-testid='radar-tab']")
+				err = radarTab.Click()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying export button is visible")
+				exportBtn := page.Locator("[data-testid='export-excel-btn']")
+				err = exportBtn.WaitFor(playwright.LocatorWaitForOptions{
+					State:   playwright.WaitForSelectorStateVisible,
+					Timeout: playwright.Float(10000),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				GinkgoWriter.Printf("Export to Excel button is visible for Team Lead\n")
+			})
+		})
+	})
+
 	Describe("Team Lead Survey Access", func() {
 		Context("when Team Lead wants to take a survey", func() {
 			It("should allow Team Lead to complete health check survey", func() {

--- a/tests/acceptance/e2e_user_home_test.go
+++ b/tests/acceptance/e2e_user_home_test.go
@@ -79,19 +79,10 @@ var _ = Describe("E2E: User Home Page and Survey History", func() {
 
 				By("Completing first dimension with a comment")
 				// Select score (Green = 3)
+				// Note: e2e_demo is a Team Member (level-5) — trend input is hidden for individual surveys.
 				err = page.Locator("[data-dimension='mission'][data-score='3']").Click()
 				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(500 * time.Millisecond) // Increased wait for React state update
-
-				// Select trend (Improving) - wait for trend buttons to appear after score selection
-				err = page.Locator("[data-dimension='mission'][data-trend='improving']").WaitFor(playwright.LocatorWaitForOptions{
-					State:   playwright.WaitForSelectorStateVisible,
-					Timeout: playwright.Float(5000),
-				})
-				Expect(err).NotTo(HaveOccurred())
-				err = page.Locator("[data-dimension='mission'][data-trend='improving']").Click()
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(500 * time.Millisecond) // Increased wait for React state update
+				time.Sleep(500 * time.Millisecond) // Wait for React state update
 
 				// Add a comment - THIS IS THE KEY TEST
 				commentTextarea := page.Locator("[data-dimension='mission'] ~ * textarea, textarea")
@@ -109,24 +100,24 @@ var _ = Describe("E2E: User Home Page and Survey History", func() {
 				time.Sleep(500 * time.Millisecond)
 
 				By("Completing remaining dimensions without comments (for speed)")
-				dimensions := []struct {
+				// Note: e2e_demo is a Team Member (level-5) — trend input is hidden for individual surveys.
+				remainingDimensions := []struct {
 					id    string
 					score int
-					trend string
 				}{
-					{"value", 2, "stable"},
-					{"speed", 2, "stable"},
-					{"fun", 3, "improving"},
-					{"health", 2, "stable"},
-					{"learning", 3, "improving"},
-					{"support", 2, "stable"},
-					{"pawns", 3, "improving"},
-					{"release", 2, "stable"},
-					{"process", 2, "stable"},
-					{"teamwork", 3, "improving"},
+					{"value", 2},
+					{"speed", 2},
+					{"fun", 3},
+					{"health", 2},
+					{"learning", 3},
+					{"support", 2},
+					{"pawns", 3},
+					{"release", 2},
+					{"process", 2},
+					{"teamwork", 3},
 				}
 
-				for i, dim := range dimensions {
+				for i, dim := range remainingDimensions {
 					// Select score
 					scoreSelector := "[data-dimension='" + dim.id + "'][data-score='" + string(rune('0'+dim.score)) + "']"
 					err = page.Locator(scoreSelector).WaitFor(playwright.LocatorWaitForOptions{
@@ -136,24 +127,13 @@ var _ = Describe("E2E: User Home Page and Survey History", func() {
 					Expect(err).NotTo(HaveOccurred())
 					err = page.Locator(scoreSelector).Click()
 					Expect(err).NotTo(HaveOccurred())
-					time.Sleep(500 * time.Millisecond) // Increased wait for React state update
-
-					// Select trend - wait for trend buttons to appear after score selection
-					trendSelector := "[data-dimension='" + dim.id + "'][data-trend='" + dim.trend + "']"
-					err = page.Locator(trendSelector).WaitFor(playwright.LocatorWaitForOptions{
-						State:   playwright.WaitForSelectorStateVisible,
-						Timeout: playwright.Float(5000), // Increased timeout
-					})
-					Expect(err).NotTo(HaveOccurred())
-					err = page.Locator(trendSelector).Click()
-					Expect(err).NotTo(HaveOccurred())
-					time.Sleep(500 * time.Millisecond) // Increased wait for React state update
+					time.Sleep(500 * time.Millisecond) // Wait for React state update
 
 					// Click Next (except for last dimension)
-					if i < len(dimensions)-1 {
+					if i < len(remainingDimensions)-1 {
 						err = page.Locator("button:has-text('Next')").Click()
 						Expect(err).NotTo(HaveOccurred())
-						time.Sleep(500 * time.Millisecond) // Increased wait for navigation
+						time.Sleep(500 * time.Millisecond)
 					}
 				}
 


### PR DESCRIPTION
- **feat(survey): hide trend input for team members**
- **feat(dashboard): add score band legend to Team Lead and Manager dashboards**
- **feat(export): add Excel export for Team Lead and Manager dashboards**
- **fix(survey): show trend on post-workshop survey regardless of member role**
- **fix(export): show export button as soon as health data loads**
- **fix(export): grant canExportData to Team Lead and bust stale localStorage config**
- **fix(e2e): update survey tests to handle hidden trend for Team Member (level-5)**
- **fix(e2e): clean up autosave test sessions and fix comment textarea locator**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Excel export to Team Lead and Manager dashboards, adds a score band legend, and hides trend input for Team Members on individual surveys (still shown for post‑workshop). Tightens export permissions and fixes validation messages.

- **New Features**
  - Team Member surveys: hide trend on individual surveys; show trend on post‑workshop; role‑aware validation.
  - Score band legend on Team Lead and Manager dashboards; distribution badges include band labels in tooltips.
  - Excel export via `xlsx`: Team Lead (Summary, Individual Responses, Distribution) and Manager (Team Summary, Dimension Breakdown).

- **Bug Fixes**
  - Export button appears as soon as health data loads; gated by `canExportData` only.
  - Enable `canExportData` for Team Lead; add org config version to replace stale `localStorage`.
  - Align incomplete submission message with trend requirement; E2E updates for hidden trend (level‑5), autosave as Team Lead, session cleanup, and textarea locator.

<sup>Written for commit cafe6f876222f5b7939a476fe73a181775b092d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

