### PR TITLE
fix(dashboard): fix distribution labels, remove member avg column, improve trends UX

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -311,14 +311,6 @@ export default function DashboardPage() {
     [matrixDims, individualResponses]
   );
 
-  const matrixOverallAvg = useMemo(
-    () => matrixDimAvgs.length > 0
-      ? matrixDimAvgs.filter((a) => a > 0).reduce((a, b) => a + b, 0) /
-        (matrixDimAvgs.filter((a) => a > 0).length || 1)
-      : 0,
-    [matrixDimAvgs]
-  );
-
   // Breakdown view: percentage bars sorted worst-first
   const breakdownData = useMemo(
     () => [...distribution]
@@ -815,12 +807,19 @@ export default function DashboardPage() {
                           /* Chart view — original grouped bar chart */
                           <div data-testid="distribution-chart" style={{ width: '100%', height: 500 }}>
                           <ResponsiveContainer width="100%" height={500}>
-                            <BarChart data={distribution}>
+                            <BarChart data={distribution} margin={{ top: 8, right: 16, left: 0, bottom: 80 }}>
                               <CartesianGrid strokeDasharray="3 3" />
-                              <XAxis dataKey="dimension" />
+                              <XAxis
+                                dataKey="dimension"
+                                interval={0}
+                                angle={-35}
+                                textAnchor="end"
+                                tick={{ fontSize: 12, fill: '#374151' }}
+                                height={80}
+                              />
                               <YAxis />
                               <Tooltip />
-                              <Legend />
+                              <Legend verticalAlign="top" />
                               <Bar dataKey="red" fill="#EF4444" name="Red (Poor)" />
                               <Bar dataKey="yellow" fill="#F59E0B" name="Yellow (Medium)" />
                               <Bar dataKey="green" fill="#10B981" name="Green (Good)" />
@@ -894,18 +893,10 @@ export default function DashboardPage() {
                                         </span>
                                       </th>
                                     ))}
-                                    <th className="px-3 py-3 text-center font-semibold text-gray-700 min-w-[64px] border-l border-gray-200">
-                                      Avg
-                                    </th>
                                   </tr>
                                 </thead>
                                 <tbody>
                                   {individualResponses.map((response, idx) => {
-                                    const memberScores = response.responses.filter((r) => r.score > 0);
-                                    const memberAvg =
-                                      memberScores.length > 0
-                                        ? memberScores.reduce((sum, r) => sum + r.score, 0) / memberScores.length
-                                        : 0;
                                     return (
                                       <tr
                                         key={idx}
@@ -990,14 +981,6 @@ export default function DashboardPage() {
                                             </td>
                                           );
                                         })}
-                                        <td className="px-3 py-3 text-center border-l border-gray-200">
-                                          <span
-                                            className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold"
-                                            style={getAvgBadgeStyle(memberAvg)}
-                                          >
-                                            {memberAvg > 0 ? memberAvg.toFixed(1) : '—'}
-                                          </span>
-                                        </td>
                                       </tr>
                                     );
                                   })}
@@ -1016,14 +999,6 @@ export default function DashboardPage() {
                                         </span>
                                       </td>
                                     ))}
-                                    <td className="px-3 py-3 text-center border-l border-gray-200">
-                                      <span
-                                        className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold"
-                                        style={getAvgBadgeStyle(matrixOverallAvg)}
-                                      >
-                                        {matrixOverallAvg > 0 ? matrixOverallAvg.toFixed(1) : '—'}
-                                      </span>
-                                    </td>
                                   </tr>
                                 </tbody>
                               </table>
@@ -1209,8 +1184,11 @@ export default function DashboardPage() {
                     <div className="flex justify-between items-center mb-6">
                       <div>
                         <h2 className="text-xl font-semibold text-gray-900">Health Trends Over Time</h2>
-                        {trendsView === 'dimensions' && trends.length > 0 && (
-                          <p className="text-xs text-gray-400 mt-0.5">One card per dimension — score vs. time</p>
+                        {trends.length > 0 && (
+                          <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+                            <Info className="w-3 h-3 flex-shrink-0" />
+                            Hover over a dot to see the assessment period and score
+                          </p>
                         )}
                       </div>
                       {trends.length > 0 && (
@@ -1309,8 +1287,8 @@ export default function DashboardPage() {
                                           dataKey="value"
                                           stroke={lineColor}
                                           strokeWidth={2}
-                                          dot={{ r: 2, fill: lineColor }}
-                                          activeDot={{ r: 3 }}
+                                          dot={{ r: 3, fill: lineColor }}
+                                          activeDot={{ r: 4 }}
                                         />
                                         <Tooltip
                                           contentStyle={{
@@ -1329,7 +1307,7 @@ export default function DashboardPage() {
                                           itemStyle={{ color: '#d1fae5' }}
                                           cursor={{ stroke: '#6366f1', strokeWidth: 1, strokeDasharray: '3 3' }}
                                           formatter={(v: number) => [v.toFixed(2), 'Score']}
-                                          labelFormatter={(period) => period}
+                                          labelFormatter={(period) => `Period: ${period}`}
                                         />
                                       </LineChart>
                                     </ResponsiveContainer>
@@ -1337,13 +1315,6 @@ export default function DashboardPage() {
                                     <div className="h-[52px] flex items-center justify-center text-xs text-gray-300">
                                       Single period
                                     </div>
-                                  )}
-
-                                  {/* Latest period label */}
-                                  {data.length > 0 && (
-                                    <p className="text-xs text-gray-400 truncate text-right">
-                                      {data[data.length - 1].period}
-                                    </p>
                                   )}
                                 </div>
                               );

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1321,28 +1321,92 @@ export default function DashboardPage() {
                             })}
                           </div>
                         ) : (
-                          /* Overview — original 11-line chart */
-                          <div data-testid="trends-chart" style={{ width: '100%', height: 500 }}>
-                          <ResponsiveContainer width="100%" height={500}>
-                            <LineChart data={trends}>
-                              <CartesianGrid strokeDasharray="3 3" />
-                              <XAxis dataKey="period" />
-                              <YAxis domain={[0, 3]} />
-                              <Tooltip />
-                              <Legend />
-                              {HEALTH_DIMENSIONS.map((dim, idx) => (
-                                <Line
-                                  key={dim.id}
-                                  type="monotone"
-                                  dataKey={dim.id}
-                                  name={dim.name}
-                                  stroke={`hsl(${idx * 30}, 70%, 50%)`}
-                                  strokeWidth={2}
-                                />
-                              ))}
-                            </LineChart>
-                          </ResponsiveContainer>
-                          </div>
+                          /* Overview — 11-line chart with perceptual palette + focused tooltip */
+                          (() => {
+                            // Hand-picked perceptually-distinct colours (hue + lightness varied)
+                            const DIM_COLORS = [
+                              '#6366f1', // indigo
+                              '#10b981', // emerald
+                              '#f59e0b', // amber
+                              '#ef4444', // red
+                              '#3b82f6', // blue
+                              '#8b5cf6', // violet
+                              '#14b8a6', // teal
+                              '#f97316', // orange
+                              '#ec4899', // pink
+                              '#84cc16', // lime
+                              '#64748b', // slate
+                            ];
+                            // Dash patterns to distinguish lines beyond colour alone
+                            const DASHES = ['0', '6 3', '3 3', '8 3 3 3', '6 3 3 3', '0', '6 3', '3 3', '8 3 3 3', '6 3 3 3', '0'];
+                            return (
+                              <div data-testid="trends-chart">
+                                <ResponsiveContainer width="100%" height={420}>
+                                  <LineChart
+                                    data={trends}
+                                    margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
+                                  >
+                                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                                    <XAxis
+                                      dataKey="period"
+                                      tick={{ fontSize: 12, fill: '#6b7280' }}
+                                    />
+                                    <YAxis
+                                      domain={[0.8, 3.2]}
+                                      ticks={[1, 1.5, 2, 2.5, 3]}
+                                      tickFormatter={(v) => v === 1 ? 'Red' : v === 2 ? 'Yellow' : v === 3 ? 'Green' : String(v)}
+                                      tick={{ fontSize: 11, fill: '#9ca3af' }}
+                                      width={52}
+                                    />
+                                    <Tooltip
+                                      contentStyle={{
+                                        fontSize: '12px',
+                                        padding: '8px 12px',
+                                        borderRadius: '8px',
+                                        backgroundColor: '#1f2937',
+                                        border: '1px solid #374151',
+                                        color: '#f9fafb',
+                                        boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                                      }}
+                                      labelStyle={{ color: '#9ca3af', fontWeight: 600, marginBottom: '6px' }}
+                                      itemStyle={{ color: '#f9fafb', padding: '1px 0' }}
+                                      formatter={(value: number, name: string) => [value.toFixed(2), name]}
+                                      labelFormatter={(period) => `Period: ${period}`}
+                                    />
+                                    {HEALTH_DIMENSIONS.map((dim, idx) => (
+                                      <Line
+                                        key={dim.id}
+                                        type="monotone"
+                                        dataKey={dim.id}
+                                        name={dim.name}
+                                        stroke={DIM_COLORS[idx]}
+                                        strokeWidth={2}
+                                        strokeDasharray={DASHES[idx]}
+                                        dot={{ r: 3, fill: DIM_COLORS[idx], strokeWidth: 0 }}
+                                        activeDot={{ r: 5, strokeWidth: 2, stroke: '#fff' }}
+                                      />
+                                    ))}
+                                  </LineChart>
+                                </ResponsiveContainer>
+                                {/* Compact legend grid below chart */}
+                                <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1.5 mt-3 px-1">
+                                  {HEALTH_DIMENSIONS.map((dim, idx) => (
+                                    <div key={dim.id} className="flex items-center gap-2 min-w-0">
+                                      <svg width="20" height="10" className="flex-shrink-0">
+                                        <line
+                                          x1="0" y1="5" x2="20" y2="5"
+                                          stroke={DIM_COLORS[idx]}
+                                          strokeWidth="2"
+                                          strokeDasharray={DASHES[idx]}
+                                        />
+                                      </svg>
+                                      <span className="text-xs text-gray-600 truncate">{dim.name}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            );
+                          })()
                         )}
                       </>
 


### PR DESCRIPTION
## Summary

- **Distribution → Chart view**: all 11 dimension names are now fully visible — labels are rotated −35° with `interval={0}` so none are skipped or clipped; Legend moved above bars to prevent overlap
- **Individual Responses → Matrix**: removed the per-member Avg column on the right (it duplicated information and cluttered the table); the Team Average row at the bottom is retained unchanged
- **Trends → By Dimension**: removed the per-card latest-period label that only showed the most recent period and created a false impression that all cards shared that same period; replaced with a single hint line below the heading ("Hover over a dot to see the assessment period and score"); tooltip label prefix is now `Period: <name>` for clarity; dots are slightly larger (r=3) to make hover targeting easier

## Regression & test impact

- No new test assertions needed — no E2E test targets the removed Avg column header, the per-card period label text, or the X-axis label positions
- Existing E2E tests that assert on `[data-testid='distribution-chart']`, `[data-testid='response-card']`, `[data-testid='trends-chart-section']` are unaffected
- TypeScript compiles cleanly with zero errors (`npx tsc --noEmit`)
- Removed two now-unused computed values (`matrixOverallAvg` useMemo and `memberAvg` row variable) to keep the code clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dashboard readability: full labels in Distribution, a cleaner Individual Responses matrix, and clearer Trends with better hints, tooltips, and a more legible Overview chart. Also adjusts legend placement, color/dash patterns, and dot sizes for easier scanning and hovering.

- **UI Improvements**
  - Distribution: rotate X-axis labels −35° with `interval={0}`; move legend to top to avoid overlap.
  - Individual Responses: remove per‑member Avg column; keep Team Average row.
  - Trends (By Dimension): remove per‑card latest‑period label; add a hint under the heading; tooltip label now “Period: <name>”; slightly larger dots for easier hover.
  - Trends (Overview): distinct color palette + alternating dashes; Y-axis domain [0.8, 3.2] with Red/Yellow/Green ticks; dark tooltip with “Period: …”; dots and active dots for targeting; replace chart legend with a compact grid below.

- **Refactors**
  - Removed unused `matrixOverallAvg` and `memberAvg` computed values.

<sup>Written for commit 0cd3a5ef28c52f327db09999936c732b097923e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

