### PR TITLE
fix(survey): handle half-yearly and yearly cadences in next survey date calculation

### DIFF
--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -28,6 +28,12 @@ function getNextSurveyDate(lastSurveyDate: string, cadence: string): Date {
     case 'quarterly':
       next.setMonth(last.getMonth() + 3);
       break;
+    case 'half-yearly':
+      next.setMonth(last.getMonth() + 6);
+      break;
+    case 'yearly':
+      next.setFullYear(last.getFullYear() + 1);
+      break;
     default:
       next.setMonth(last.getMonth() + 1);
   }


### PR DESCRIPTION
## Summary

- `half-yearly` and `yearly` cadences were not handled in `getNextSurveyDate()` and fell through to the `default` case, which added only 1 month regardless of cadence
- Teams on a half-yearly or yearly cadence incorrectly showed the next survey date as 1 month after the last submission, causing it to appear overdue prematurely

## Root Cause

`getNextSurveyDate()` in `frontend/app/home/page.tsx` had no explicit cases for `half-yearly` or `yearly`, both of which are valid values per the `Team.cadence` type definition.

## Fix

Added explicit cases to the switch statement:
- `half-yearly` → +6 months
- `yearly` → +1 year (via `setFullYear` to correctly handle year boundaries)

## Before / After

| Cadence | Last Survey | Before (wrong) | After (correct) |
|---------|------------|----------------|-----------------|
| half-yearly | Mar 25, 2026 | Apr 25, 2026 ❌ | Sep 25, 2026 ✅ |
| yearly | Mar 25, 2026 | Apr 25, 2026 ❌ | Mar 25, 2027 ✅ |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes next survey date calculation for half-yearly and yearly cadences so teams aren’t marked overdue after one month. Ensures +6 months and +1 year are applied correctly.

- **Bug Fixes**
  - Added explicit cases in getNextSurveyDate: half-yearly → +6 months; yearly → +1 year using setFullYear to handle year boundaries.

<sup>Written for commit 629e4ca3bfb8ffdaba302898c5bd35b2cd0345a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

