### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,10 @@ assignees: []
 ---
 
 <!--
-Thanks for helping improve Team Health Check! Please keep the section headings below —
-they mirror the structure the maintainers use for every tracked issue, which
-keeps the backlog consistent and quick to triage.
+Thanks for helping improve Team Health Check! Before opening, please skim the
+contributing guide: https://github.com/guidewire-oss/teams360/blob/main/CONTRIBUTING.md
+Please keep the section headings below — they mirror the structure the maintainers
+use for every tracked issue, which keeps the backlog consistent and quick to triage.
 Delete this comment. You may delete any "(optional)" section you can't fill in.
 -->
 
@@ -46,6 +47,10 @@ Delete this comment. You may delete any "(optional)" section you can't fill in.
 - Version / tag / commit:
 - Browser / OS:
 - Deployment (local, Docker, Kubernetes):
+
+## Logs / Screenshots (optional)
+<!-- Paste relevant logs (backend/CI output, browser console) or attach screenshots.
+     Use code fences for logs; redact any secrets or personal data first. -->
 
 ---
 <!-- Triage — a maintainer will confirm/adjust these. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,4 +51,4 @@ Delete this comment. You may delete any "(optional)" section you can't fill in.
 <!-- Triage — a maintainer will confirm/adjust these. -->
 **Severity:** <!-- Critical / High / Medium / Low --> &nbsp;·&nbsp; **Area:** <!-- Security / Frontend / Data / Build-CI / Docs -->
 
-> 🔒 **Is this a security vulnerability?** Do **not** file it here. Report it privately — see [SECURITY.md](../SECURITY.md) and open a [security advisory](https://github.com/guidewire-oss/teams360/security/advisories/new).
+> 🔒 **Is this a security vulnerability?** Do **not** file it here. Report it privately following our [security policy](https://github.com/guidewire-oss/teams360/security/policy).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: "🐛 Bug report"
+about: "Report a defect in Team360 (backend, frontend, data, build/CI)"
+title: "[Bug] <short summary>"
+labels: ["bug"]
+assignees: []
+---
+
+<!--
+Thanks for helping improve Team360! Please keep the section headings below —
+they mirror the structure the maintainers use for every tracked issue, which
+keeps the backlog consistent and quick to triage.
+Delete this comment. You may delete any "(optional)" section you can't fill in.
+-->
+
+## Summary
+<!-- One or two sentences: what is wrong? -->
+
+## Impact
+<!-- Who/what is affected and the real-world consequence. Bullets are fine. -->
+-
+
+## Where
+<!-- File path + line(s) if you know them, e.g. `backend/interfaces/api/v1/health_check_handler.go:124`.
+     Otherwise the page, endpoint, or area (Frontend / Backend / Data / Build-CI / Docs). -->
+-
+
+## How to reproduce / observe
+<!-- Numbered steps so a maintainer can reproduce it. For non-runtime issues, describe how to observe it (e.g. "read X"). -->
+1.
+2.
+3.
+
+**Expected:**
+**Actual:**
+
+## Proposed fix (optional)
+<!-- If you have a suggestion, describe it. -->
+
+## Acceptance criteria
+<!-- What must be true for this to be considered fixed? -->
+- [ ]
+- [ ]
+
+## Environment (optional)
+- Version / tag / commit:
+- Browser / OS:
+- Deployment (local, Docker, Kubernetes):
+
+---
+<!-- Triage — a maintainer will confirm/adjust these. -->
+**Severity:** <!-- Critical / High / Medium / Low --> &nbsp;·&nbsp; **Area:** <!-- Security / Frontend / Data / Build-CI / Docs -->
+
+> 🔒 **Is this a security vulnerability?** Do **not** file it here. Report it privately — see [SECURITY.md](../SECURITY.md) and open a [security advisory](https://github.com/guidewire-oss/teams360/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,13 @@
 ---
 name: "🐛 Bug report"
-about: "Report a defect in Team360 (backend, frontend, data, build/CI)"
+about: "Report a defect in Team Health Check (backend, frontend, data, build/CI)"
 title: "[Bug] <short summary>"
 labels: ["bug"]
 assignees: []
 ---
 
 <!--
-Thanks for helping improve Team360! Please keep the section headings below —
+Thanks for helping improve Team Health Check! Please keep the section headings below —
 they mirror the structure the maintainers use for every tracked issue, which
 keeps the backlog consistent and quick to triage.
 Delete this comment. You may delete any "(optional)" section you can't fill in.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: "🔒 Report a security vulnerability"
-    url: "https://github.com/guidewire-oss/teams360/security/advisories/new"
-    about: "Report vulnerabilities privately via a security advisory — never as a public issue."
+    url: "https://github.com/guidewire-oss/teams360/security/policy"
+    about: "Report vulnerabilities privately per our security policy — never as a public issue."
   - name: "💬 Questions & discussion"
     url: "https://github.com/guidewire-oss/teams360/discussions"
     about: "Ask questions, share ideas, or get help using Team Health Check."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,4 +8,4 @@ contact_links:
     about: "Report vulnerabilities privately via a security advisory — never as a public issue."
   - name: "💬 Questions & discussion"
     url: "https://github.com/guidewire-oss/teams360/discussions"
-    about: "Ask questions, share ideas, or get help using Team360."
+    about: "Ask questions, share ideas, or get help using Team Health Check."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# .github/ISSUE_TEMPLATE/config.yml
+# Forces contributors to pick a template (no blank issues) and routes
+# security reports + questions away from the public issue tracker.
+blank_issues_enabled: false
+contact_links:
+  - name: "🔒 Report a security vulnerability"
+    url: "https://github.com/guidewire-oss/teams360/security/advisories/new"
+    about: "Report vulnerabilities privately via a security advisory — never as a public issue."
+  - name: "💬 Questions & discussion"
+    url: "https://github.com/guidewire-oss/teams360/discussions"
+    about: "Ask questions, share ideas, or get help using Team360."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: "✨ Feature request / enhancement"
-about: "Suggest a capability or improvement for Team360"
+about: "Suggest a capability or improvement for Team Health Check"
 title: "[Feature] <short summary>"
 labels: ["enhancement"]
 assignees: []
@@ -8,7 +8,7 @@ assignees: []
 
 <!--
 Keep the headings — they mirror the structure maintainers use for tracked issues.
-Team360's ethos is "support, not surveillance": features should help teams improve,
+Team Health Check's ethos is "support, not surveillance": features should help teams improve,
 never be weaponized for performance review. Please keep that in mind.
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: []
 ---
 
 <!--
+Before opening, please skim the contributing guide:
+https://github.com/guidewire-oss/teams360/blob/main/CONTRIBUTING.md
 Keep the headings — they mirror the structure maintainers use for tracked issues.
 Team Health Check's ethos is "support, not surveillance": features should help teams improve,
 never be weaponized for performance review. Please keep that in mind.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: "✨ Feature request / enhancement"
+about: "Suggest a capability or improvement for Team360"
+title: "[Feature] <short summary>"
+labels: ["enhancement"]
+assignees: []
+---
+
+<!--
+Keep the headings — they mirror the structure maintainers use for tracked issues.
+Team360's ethos is "support, not surveillance": features should help teams improve,
+never be weaponized for performance review. Please keep that in mind.
+-->
+
+## Summary
+<!-- One or two sentences: what do you want? -->
+
+## Why it matters
+<!-- The problem this solves / the user value. -->
+-
+
+## Proposed change
+<!-- What should change — behavior, UI, API, or data. -->
+
+## Alternatives considered (optional)
+
+## Acceptance criteria
+<!-- What must be true for this to be considered done? -->
+- [ ]
+- [ ]
+
+---
+**Area:** <!-- Frontend / Backend / Data / Docs / DevEx -->


### PR DESCRIPTION
## What

Adds `.github/ISSUE_TEMPLATE/` — GitHub's modern multi-template layout (one file per type).

- **`bug_report.md`** — structured bug report form.
- **`feature_request.md`** — feature request / enhancement form.
- **`config.yml`** — disables blank issues and routes security reports to advisories and questions to Discussions.

## Why

A lone `.github/ISSUE_TEMPLATE.md` only gives one option and ignores `name:`/`about:` front matter. The folder layout gives contributors the full set and keeps issues consistent to triage.