### PR TITLE
docs: update README version prerequisites to match CI and Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Monitor your team's health with detailed breakdowns and individual response trac
 
 ### Prerequisites
 
-- **Node.js 18+** (for frontend)
+- **Node.js 22+** (for frontend)
 - **Go 1.25+** (for backend)
-- **PostgreSQL 14+** (for database)
+- **PostgreSQL 17+** (for database)
 - **Docker** (recommended, for running PostgreSQL)
 
 ### One-Command Setup
@@ -83,7 +83,7 @@ docker run -d \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=teams360 \
   -p 5432:5432 \
-  postgres:16-alpine
+  postgres:17-alpine
 ```
 
 Or use an existing PostgreSQL instance and set the connection string.


### PR DESCRIPTION
Closes #95

Updates the Prerequisites section to reflect the actual versions used in CI, Docker, and development tooling:

- Node.js 18+ ? 22+
- PostgreSQL 14+ ? 17+
- postgres:16-alpine ? postgres:17-alpine in Docker run example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align README prerequisites with CI and Docker to prevent setup mismatches. Updates Node.js to 22+, PostgreSQL to 17+, and switches the Docker example to `postgres:17-alpine`.

<sup>Written for commit f351c7b7399b6795f4ec9ef6726a4efa68c10860. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/teams360/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

