### PR TITLE
[OSS-3] Add SPDX-License-Identifier: Apache-2.0 headers to all source files

### DIFF
--- a/backend/application/commands/submit_health_check.go
+++ b/backend/application/commands/submit_health_check.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package commands
 
 import (

--- a/backend/application/queries/get_health_dimensions.go
+++ b/backend/application/queries/get_health_dimensions.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package queries
 
 import (

--- a/backend/application/queries/get_team_sessions.go
+++ b/backend/application/queries/get_team_sessions.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package queries
 
 import (

--- a/backend/application/services/jwt_service.go
+++ b/backend/application/services/jwt_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package services
 
 import (

--- a/backend/application/services/notification_service.go
+++ b/backend/application/services/notification_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package services
 
 import (

--- a/backend/application/services/password_reset_service.go
+++ b/backend/application/services/password_reset_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package services
 
 import (

--- a/backend/application/trends/trends_service.go
+++ b/backend/application/trends/trends_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package trends
 
 import (

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/backend/domain/healthcheck/healthcheck.go
+++ b/backend/domain/healthcheck/healthcheck.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package healthcheck
 
 import "context"

--- a/backend/domain/organization/organization.go
+++ b/backend/domain/organization/organization.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package organization
 
 import (

--- a/backend/domain/team/team.go
+++ b/backend/domain/team/team.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package team
 
 import (

--- a/backend/domain/user/user.go
+++ b/backend/domain/user/user.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package user
 
 import (

--- a/backend/infrastructure/email/email.go
+++ b/backend/infrastructure/email/email.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package email
 
 import "context"

--- a/backend/infrastructure/email/ses_service.go
+++ b/backend/infrastructure/email/ses_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package email
 
 import (

--- a/backend/infrastructure/email/smtp_service.go
+++ b/backend/infrastructure/email/smtp_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package email
 
 import (

--- a/backend/infrastructure/email/templates.go
+++ b/backend/infrastructure/email/templates.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package email
 
 import (

--- a/backend/infrastructure/persistence/postgres/health_check_repository.go
+++ b/backend/infrastructure/persistence/postgres/health_check_repository.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/infrastructure/persistence/postgres/migrations/000001_create_health_dimensions.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000001_create_health_dimensions.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Drop health_dimensions table
 DROP INDEX IF EXISTS idx_dimensions_active;
 DROP TABLE IF EXISTS health_dimensions CASCADE;

--- a/backend/infrastructure/persistence/postgres/migrations/000001_create_health_dimensions.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000001_create_health_dimensions.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Create health_dimensions table
 CREATE TABLE IF NOT EXISTS health_dimensions (
     id VARCHAR(50) PRIMARY KEY,

--- a/backend/infrastructure/persistence/postgres/migrations/000002_create_health_check_sessions.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000002_create_health_check_sessions.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Drop health_check_sessions table
 DROP INDEX IF EXISTS idx_sessions_team_date;
 DROP INDEX IF EXISTS idx_sessions_user_date;

--- a/backend/infrastructure/persistence/postgres/migrations/000002_create_health_check_sessions.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000002_create_health_check_sessions.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Create health_check_sessions table
 CREATE TABLE IF NOT EXISTS health_check_sessions (
     id VARCHAR(100) PRIMARY KEY,

--- a/backend/infrastructure/persistence/postgres/migrations/000003_create_health_check_responses.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000003_create_health_check_responses.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Drop health_check_responses table
 DROP INDEX IF EXISTS idx_responses_session_dimension;
 DROP INDEX IF EXISTS idx_responses_dimension_score;

--- a/backend/infrastructure/persistence/postgres/migrations/000003_create_health_check_responses.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000003_create_health_check_responses.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Create health_check_responses table
 CREATE TABLE IF NOT EXISTS health_check_responses (
     id SERIAL PRIMARY KEY,

--- a/backend/infrastructure/persistence/postgres/migrations/000004_seed_health_dimensions.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000004_seed_health_dimensions.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove seeded health dimensions
 DELETE FROM health_dimensions WHERE id IN (
     'mission', 'value', 'speed', 'fun', 'health',

--- a/backend/infrastructure/persistence/postgres/migrations/000004_seed_health_dimensions.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000004_seed_health_dimensions.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Seed health dimensions based on Spotify Squad Health Check Model
 -- Enhanced with Team360 additions
 

--- a/backend/infrastructure/persistence/postgres/migrations/000005_create_users_and_teams.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000005_create_users_and_teams.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP TABLE IF EXISTS team_supervisors;
 DROP TABLE IF EXISTS team_members;
 DROP TABLE IF EXISTS teams;

--- a/backend/infrastructure/persistence/postgres/migrations/000005_create_users_and_teams.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000005_create_users_and_teams.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Users table for organizational hierarchy
 CREATE TABLE users (
     id VARCHAR(255) PRIMARY KEY,

--- a/backend/infrastructure/persistence/postgres/migrations/000006_add_password_hash.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000006_add_password_hash.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add password_hash column to users table for authentication
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255) NOT NULL DEFAULT 'demo';
 

--- a/backend/infrastructure/persistence/postgres/migrations/000007_seed_demo_users.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000007_seed_demo_users.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove demo users
 DELETE FROM users WHERE id IN (
     'vp1', 'dir1', 'dir2', 'mgr1', 'mgr2', 'mgr3',

--- a/backend/infrastructure/persistence/postgres/migrations/000007_seed_demo_users.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000007_seed_demo_users.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Administrator (always created — needed for login in all environments)
 -- Demo users are now seeded at app startup via SeedDemoData() when APP_ENV=demo
 INSERT INTO users (id, username, email, full_name, hierarchy_level_id, reports_to, password_hash)

--- a/backend/infrastructure/persistence/postgres/migrations/000008_add_team_cadence.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000008_add_team_cadence.down.sql
@@ -1,2 +1,4 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove cadence column from teams table
 ALTER TABLE teams DROP COLUMN IF EXISTS cadence;

--- a/backend/infrastructure/persistence/postgres/migrations/000008_add_team_cadence.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000008_add_team_cadence.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add cadence column to teams table
 ALTER TABLE teams ADD COLUMN cadence VARCHAR(50) DEFAULT 'quarterly';
 

--- a/backend/infrastructure/persistence/postgres/migrations/000009_create_hierarchy_levels.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000009_create_hierarchy_levels.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove foreign key constraint from users table
 ALTER TABLE users DROP CONSTRAINT IF EXISTS fk_users_hierarchy_level;
 

--- a/backend/infrastructure/persistence/postgres/migrations/000009_create_hierarchy_levels.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000009_create_hierarchy_levels.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Create hierarchy_levels table for organizational structure
 CREATE TABLE IF NOT EXISTS hierarchy_levels (
     id VARCHAR(50) PRIMARY KEY,

--- a/backend/infrastructure/persistence/postgres/migrations/000010_add_hierarchy_level_color.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000010_add_hierarchy_level_color.down.sql
@@ -1,2 +1,4 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove color column from hierarchy_levels table
 ALTER TABLE hierarchy_levels DROP COLUMN IF EXISTS color;

--- a/backend/infrastructure/persistence/postgres/migrations/000010_add_hierarchy_level_color.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000010_add_hierarchy_level_color.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add color column to hierarchy_levels table
 ALTER TABLE hierarchy_levels ADD COLUMN IF NOT EXISTS color VARCHAR(20);
 

--- a/backend/infrastructure/persistence/postgres/migrations/000011_add_hierarchy_permissions.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000011_add_hierarchy_permissions.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove additional permission columns from hierarchy_levels table
 ALTER TABLE hierarchy_levels DROP COLUMN IF EXISTS can_configure_system;
 ALTER TABLE hierarchy_levels DROP COLUMN IF EXISTS can_view_reports;

--- a/backend/infrastructure/persistence/postgres/migrations/000011_add_hierarchy_permissions.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000011_add_hierarchy_permissions.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add additional permission columns to hierarchy_levels table
 ALTER TABLE hierarchy_levels ADD COLUMN IF NOT EXISTS can_configure_system BOOLEAN DEFAULT false;
 ALTER TABLE hierarchy_levels ADD COLUMN IF NOT EXISTS can_view_reports BOOLEAN DEFAULT false;

--- a/backend/infrastructure/persistence/postgres/migrations/000012_create_password_reset_tokens.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000012_create_password_reset_tokens.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Rollback password reset tokens table
 
 DROP INDEX IF EXISTS idx_password_reset_tokens_created_at;

--- a/backend/infrastructure/persistence/postgres/migrations/000012_create_password_reset_tokens.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000012_create_password_reset_tokens.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Create password reset tokens table for P0-3: Password reset flow
 -- Tokens are short-lived (1 hour) and single-use
 

--- a/backend/infrastructure/persistence/postgres/migrations/000013_add_security_constraints.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000013_add_security_constraints.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Remove security constraints (in reverse order)
 
 -- Remove indexes

--- a/backend/infrastructure/persistence/postgres/migrations/000013_add_security_constraints.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000013_add_security_constraints.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add security and data integrity constraints
 
 -- Add CHECK constraints for email format validation at database level

--- a/backend/infrastructure/persistence/postgres/migrations/000014_add_survey_type.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000014_add_survey_type.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP INDEX IF EXISTS idx_sessions_team_period_type;
 DROP INDEX IF EXISTS idx_sessions_survey_type;
 ALTER TABLE health_check_sessions DROP CONSTRAINT IF EXISTS chk_sessions_survey_type;

--- a/backend/infrastructure/persistence/postgres/migrations/000014_add_survey_type.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000014_add_survey_type.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add survey_type column to distinguish individual vs post-workshop surveys
 ALTER TABLE health_check_sessions
 ADD COLUMN survey_type VARCHAR(20) NOT NULL DEFAULT 'individual';

--- a/backend/infrastructure/persistence/postgres/migrations/000015_create_app_settings.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000015_create_app_settings.down.sql
@@ -1,1 +1,3 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP TABLE IF EXISTS app_settings;

--- a/backend/infrastructure/persistence/postgres/migrations/000015_create_app_settings.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000015_create_app_settings.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 CREATE TABLE IF NOT EXISTS app_settings (
     id INTEGER PRIMARY KEY DEFAULT 1 CONSTRAINT singleton CHECK (id = 1),
     email_notifications BOOLEAN NOT NULL DEFAULT false,

--- a/backend/infrastructure/persistence/postgres/migrations/000016_update_cadence_values.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000016_update_cadence_values.down.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Revert cadence constraint (lossy: cannot restore original weekly/biweekly values)
 ALTER TABLE teams DROP CONSTRAINT IF EXISTS chk_teams_cadence_values;
 

--- a/backend/infrastructure/persistence/postgres/migrations/000016_update_cadence_values.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000016_update_cadence_values.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Update cadence values: remove weekly/biweekly, add half-yearly/yearly
 -- This migration is lossy: weekly/biweekly are mapped to monthly and cannot be restored.
 

--- a/backend/infrastructure/persistence/postgres/migrations/000017_add_auth_type.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000017_add_auth_type.down.sql
@@ -1,2 +1,4 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE users DROP CONSTRAINT IF EXISTS chk_users_auth_type;
 ALTER TABLE users DROP COLUMN IF EXISTS auth_type;

--- a/backend/infrastructure/persistence/postgres/migrations/000017_add_auth_type.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000017_add_auth_type.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add auth_type column to users table
 -- 'local' = username/password authentication
 -- 'sso'   = authentication via external Identity Provider; password_hash unused

--- a/backend/infrastructure/persistence/postgres/migrations/000018_add_branding_settings.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000018_add_branding_settings.down.sql
@@ -1,2 +1,4 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE app_settings DROP COLUMN IF EXISTS logo_url;
 ALTER TABLE app_settings DROP COLUMN IF EXISTS company_name;

--- a/backend/infrastructure/persistence/postgres/migrations/000018_add_branding_settings.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000018_add_branding_settings.up.sql
@@ -1,2 +1,4 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS company_name TEXT NOT NULL DEFAULT 'My Company';
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS logo_url TEXT DEFAULT NULL;

--- a/backend/infrastructure/persistence/postgres/migrations/000019_add_team_distribution_list_email.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000019_add_team_distribution_list_email.down.sql
@@ -1,1 +1,3 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE teams DROP COLUMN IF EXISTS distribution_list_email;

--- a/backend/infrastructure/persistence/postgres/migrations/000019_add_team_distribution_list_email.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000019_add_team_distribution_list_email.up.sql
@@ -1,1 +1,3 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE teams ADD COLUMN distribution_list_email VARCHAR(255);

--- a/backend/infrastructure/persistence/postgres/migrations/000020_create_action_items.down.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000020_create_action_items.down.sql
@@ -1,1 +1,3 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP TABLE IF EXISTS action_items;

--- a/backend/infrastructure/persistence/postgres/migrations/000020_create_action_items.up.sql
+++ b/backend/infrastructure/persistence/postgres/migrations/000020_create_action_items.up.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: Apache-2.0
+
 CREATE TABLE action_items (
     id                VARCHAR(100)  PRIMARY KEY,
     team_id           VARCHAR(255)  NOT NULL REFERENCES teams(id) ON DELETE CASCADE,

--- a/backend/infrastructure/persistence/postgres/organization_repository.go
+++ b/backend/infrastructure/persistence/postgres/organization_repository.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/infrastructure/persistence/postgres/password_reset_repository.go
+++ b/backend/infrastructure/persistence/postgres/password_reset_repository.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/infrastructure/persistence/postgres/seed.go
+++ b/backend/infrastructure/persistence/postgres/seed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/infrastructure/persistence/postgres/team_repository.go
+++ b/backend/infrastructure/persistence/postgres/team_repository.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/infrastructure/persistence/postgres/user_repository.go
+++ b/backend/infrastructure/persistence/postgres/user_repository.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/backend/interfaces/api/middleware/cors.go
+++ b/backend/interfaces/api/middleware/cors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import "github.com/gin-gonic/gin"

--- a/backend/interfaces/api/middleware/request_logger.go
+++ b/backend/interfaces/api/middleware/request_logger.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/backend/interfaces/api/middleware/validation.go
+++ b/backend/interfaces/api/middleware/validation.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/backend/interfaces/api/v1/action_item_handler.go
+++ b/backend/interfaces/api/v1/action_item_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/action_item_routes.go
+++ b/backend/interfaces/api/v1/action_item_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/admin_api_test.go
+++ b/backend/interfaces/api/v1/admin_api_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1_test
 
 import (

--- a/backend/interfaces/api/v1/admin_handler.go
+++ b/backend/interfaces/api/v1/admin_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/admin_routes.go
+++ b/backend/interfaces/api/v1/admin_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/auth_handler.go
+++ b/backend/interfaces/api/v1/auth_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/auth_routes.go
+++ b/backend/interfaces/api/v1/auth_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/health_check_api_test.go
+++ b/backend/interfaces/api/v1/health_check_api_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1_test
 
 import (

--- a/backend/interfaces/api/v1/health_check_handler.go
+++ b/backend/interfaces/api/v1/health_check_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/health_check_routes.go
+++ b/backend/interfaces/api/v1/health_check_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/hierarchy_admin_handler.go
+++ b/backend/interfaces/api/v1/hierarchy_admin_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/manager_handler.go
+++ b/backend/interfaces/api/v1/manager_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/manager_routes.go
+++ b/backend/interfaces/api/v1/manager_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/password_reset_handler.go
+++ b/backend/interfaces/api/v1/password_reset_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/settings_admin_handler.go
+++ b/backend/interfaces/api/v1/settings_admin_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/sso_handler.go
+++ b/backend/interfaces/api/v1/sso_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/sso_routes.go
+++ b/backend/interfaces/api/v1/sso_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/suite_test.go
+++ b/backend/interfaces/api/v1/suite_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1_test
 
 import (

--- a/backend/interfaces/api/v1/team_admin_handler.go
+++ b/backend/interfaces/api/v1/team_admin_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/team_dashboard_handler.go
+++ b/backend/interfaces/api/v1/team_dashboard_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/team_dashboard_routes.go
+++ b/backend/interfaces/api/v1/team_dashboard_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/team_routes.go
+++ b/backend/interfaces/api/v1/team_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/user_admin_handler.go
+++ b/backend/interfaces/api/v1/user_admin_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/user_handler.go
+++ b/backend/interfaces/api/v1/user_handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/user_handler_test.go
+++ b/backend/interfaces/api/v1/user_handler_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/api/v1/user_routes.go
+++ b/backend/interfaces/api/v1/user_routes.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/backend/interfaces/dto/action_item_dto.go
+++ b/backend/interfaces/dto/action_item_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 import (

--- a/backend/interfaces/dto/admin_dto.go
+++ b/backend/interfaces/dto/admin_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 import "time"

--- a/backend/interfaces/dto/auth_dto.go
+++ b/backend/interfaces/dto/auth_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 // LoginRequest represents the login credentials

--- a/backend/interfaces/dto/health_check_dto.go
+++ b/backend/interfaces/dto/health_check_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 // SubmitHealthCheckRequest represents the request payload for submitting a health check

--- a/backend/interfaces/dto/manager_dto.go
+++ b/backend/interfaces/dto/manager_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 // TeamHealthSummary represents aggregated health data for a team

--- a/backend/interfaces/dto/responses.go
+++ b/backend/interfaces/dto/responses.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 import (

--- a/backend/interfaces/dto/team_dashboard_dto.go
+++ b/backend/interfaces/dto/team_dashboard_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 // TeamDashboardHealthSummary represents radar chart data (avg score per dimension)

--- a/backend/interfaces/dto/user_dto.go
+++ b/backend/interfaces/dto/user_dto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package dto
 
 // SurveyHistoryResponse represents a user's survey history

--- a/backend/interfaces/middleware/jwt_auth.go
+++ b/backend/interfaces/middleware/jwt_auth.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package logger provides structured logging using zerolog.
 // It is designed for security-conscious, cost-effective logging
 // with a focus on debugging value.

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package metrics provides OpenTelemetry metrics for Team360 product analytics and business metrics
 package metrics
 

--- a/backend/pkg/telemetry/metrics.go
+++ b/backend/pkg/telemetry/metrics.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/backend/pkg/telemetry/telemetry.go
+++ b/backend/pkg/telemetry/telemetry.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/backend/pkg/telemetry/tracer.go
+++ b/backend/pkg/telemetry/tracer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/backend/tests/acceptance/database_migration_test.go
+++ b/backend/tests/acceptance/database_migration_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/backend/tests/acceptance/health_check_repository_test.go
+++ b/backend/tests/acceptance/health_check_repository_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/database_constraints_test.go
+++ b/backend/tests/integration/database_constraints_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/manager_dashboard_test.go
+++ b/backend/tests/integration/manager_dashboard_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/password_reset_test.go
+++ b/backend/tests/integration/password_reset_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/sso_test.go
+++ b/backend/tests/integration/sso_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/suite_test.go
+++ b/backend/tests/integration/suite_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/supervisor_chain_test.go
+++ b/backend/tests/integration/supervisor_chain_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/team_results_test.go
+++ b/backend/tests/integration/team_results_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/user_admin_sso_test.go
+++ b/backend/tests/integration/user_admin_sso_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/integration/validation_middleware_test.go
+++ b/backend/tests/integration/validation_middleware_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package integration_test
 
 import (

--- a/backend/tests/testhelpers/database.go
+++ b/backend/tests/testhelpers/database.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package testhelpers
 
 import (

--- a/fix-mac-issues.sh
+++ b/fix-mac-issues.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+
 
 echo "🔧 Team360 Health Check - Mac ARM64 Fix Script"
 echo "=============================================="

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useEffect, useState, useRef, Suspense } from 'react';

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { Suspense, useState, useEffect } from 'react';

--- a/frontend/app/manager/page.tsx
+++ b/frontend/app/manager/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useEffect } from 'react';

--- a/frontend/app/survey/page.tsx
+++ b/frontend/app/survey/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect, useRef, Suspense } from 'react';

--- a/frontend/app/teams/[teamId]/TeamResultsClient.tsx
+++ b/frontend/app/teams/[teamId]/TeamResultsClient.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/app/teams/[teamId]/page.tsx
+++ b/frontend/app/teams/[teamId]/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import TeamResultsClient from './TeamResultsClient';
 
 // Static export requires at least one param. The placeholder is never used —

--- a/frontend/components/ActionItemModal.tsx
+++ b/frontend/components/ActionItemModal.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState } from 'react';

--- a/frontend/components/ActionItemsTab.tsx
+++ b/frontend/components/ActionItemsTab.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';

--- a/frontend/components/AuthGuard.tsx
+++ b/frontend/components/AuthGuard.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useEffect, useState } from 'react';

--- a/frontend/components/DimensionConfig.tsx
+++ b/frontend/components/DimensionConfig.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/frontend/components/HierarchicalDashboard.tsx
+++ b/frontend/components/HierarchicalDashboard.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/components/HierarchyConfig.tsx
+++ b/frontend/components/HierarchyConfig.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/components/OnboardingModal.tsx
+++ b/frontend/components/OnboardingModal.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState } from 'react';

--- a/frontend/components/SupervisorChainModal.tsx
+++ b/frontend/components/SupervisorChainModal.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/components/TeamMembersModal.tsx
+++ b/frontend/components/TeamMembersModal.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/frontend/components/TelemetryProvider.tsx
+++ b/frontend/components/TelemetryProvider.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 /**

--- a/frontend/lib/__tests__/assessment-period.test.ts
+++ b/frontend/lib/__tests__/assessment-period.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Tests for cadence-driven assessment period utility functions.
  *

--- a/frontend/lib/__tests__/sso.test.ts
+++ b/frontend/lib/__tests__/sso.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fetchSSOConfig } from '../sso';
 

--- a/frontend/lib/api-types.ts
+++ b/frontend/lib/api-types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * API Response Types
  * TypeScript interfaces matching backend DTOs for type-safe API integration.

--- a/frontend/lib/api/action-items.ts
+++ b/frontend/lib/api/action-items.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { authenticatedFetch } from '@/lib/auth';
 import { API_BASE_URL } from './client';
 

--- a/frontend/lib/api/admin.ts
+++ b/frontend/lib/api/admin.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Admin API Client
  *

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Shared API Client Utilities
  *

--- a/frontend/lib/api/health-checks.ts
+++ b/frontend/lib/api/health-checks.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Health Check API Client
  *

--- a/frontend/lib/api/teams.ts
+++ b/frontend/lib/api/teams.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Teams API Client
  *

--- a/frontend/lib/assessment-period.ts
+++ b/frontend/lib/assessment-period.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Utility functions for cadence-driven assessment period detection.
  *

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import Cookies from 'js-cookie';
 import type { User as DomainUser } from '@/lib/types';
 import { API_BASE_URL } from '@/lib/api/client';

--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { HealthDimension } from './types';
 
 /**

--- a/frontend/lib/org-config.ts
+++ b/frontend/lib/org-config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { OrganizationConfig, HierarchyLevel, User, Team } from './types';
 
 // Default configuration with VP -> Director -> Manager -> Team Lead -> Team Member hierarchy

--- a/frontend/lib/sso.ts
+++ b/frontend/lib/sso.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * SSO utilities: PKCE generation and OAuth Authorization Code flow helpers.
  * Uses the Web Crypto API (built into all modern browsers and the Next.js runtime).

--- a/frontend/lib/teams-data.ts
+++ b/frontend/lib/teams-data.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Team, HealthCheckSession } from './types';
 
 // Mock teams with proper supervisor chain

--- a/frontend/lib/telemetry/business-events.ts
+++ b/frontend/lib/telemetry/business-events.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Business Event Tracing for Team360 Frontend
  *

--- a/frontend/lib/telemetry/config.ts
+++ b/frontend/lib/telemetry/config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * OpenTelemetry Configuration for Team360 Frontend
  *

--- a/frontend/lib/telemetry/index.ts
+++ b/frontend/lib/telemetry/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * OpenTelemetry Telemetry Module for Team360 Frontend
  *

--- a/frontend/lib/telemetry/tracer.ts
+++ b/frontend/lib/telemetry/tracer.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * OpenTelemetry Browser Tracer for Team360 Frontend
  *

--- a/frontend/lib/telemetry/web-vitals.ts
+++ b/frontend/lib/telemetry/web-vitals.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Web Vitals Metrics Collection for Team360 Frontend
  *

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Configurable hierarchy level
 export interface HierarchyLevel {
   id: string;

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import '@testing-library/jest-dom'

--- a/kubevela/components/cnpg.cue
+++ b/kubevela/components/cnpg.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // CloudNativePG PostgreSQL Cluster Component Definition
 // Adapted from fern-platform patterns for KubeVela OAM
 // Usage: vela def apply kubevela/components/cnpg.cue

--- a/kubevela/components/gateway.cue
+++ b/kubevela/components/gateway.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Gateway Trait Definition — Service + Ingress
 // Adapted from fern-platform patterns for KubeVela OAM
 // Usage: vela def apply kubevela/components/gateway.cue

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+
 # Script to start development server on host machine with SSL bypass
 
 echo "Starting Team360 Health Check Application..."

--- a/tests/acceptance/e2e_admin_branding_test.go
+++ b/tests/acceptance/e2e_admin_branding_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_admin_dashboard_test.go
+++ b/tests/acceptance/e2e_admin_dashboard_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_admin_dimensions_test.go
+++ b/tests/acceptance/e2e_admin_dimensions_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_admin_modals_test.go
+++ b/tests/acceptance/e2e_admin_modals_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_admin_supervisor_chain_test.go
+++ b/tests/acceptance/e2e_admin_supervisor_chain_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_admin_test.go
+++ b/tests/acceptance/e2e_admin_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_assessment_periods_test.go
+++ b/tests/acceptance/e2e_assessment_periods_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_authentication_test.go
+++ b/tests/acceptance/e2e_authentication_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_authorization_test.go
+++ b/tests/acceptance/e2e_authorization_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_cadence_period_test.go
+++ b/tests/acceptance/e2e_cadence_period_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_complete_flow_test.go
+++ b/tests/acceptance/e2e_complete_flow_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_data_validation_test.go
+++ b/tests/acceptance/e2e_data_validation_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_dimension_matrix_test.go
+++ b/tests/acceptance/e2e_dimension_matrix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_error_messages_test.go
+++ b/tests/acceptance/e2e_error_messages_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_jwt_auth_test.go
+++ b/tests/acceptance/e2e_jwt_auth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_manager_dashboard_test.go
+++ b/tests/acceptance/e2e_manager_dashboard_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_member_home_test.go
+++ b/tests/acceptance/e2e_member_home_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_multi_team_test.go
+++ b/tests/acceptance/e2e_multi_team_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_session_timeout_test.go
+++ b/tests/acceptance/e2e_session_timeout_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_settings_persistence_test.go
+++ b/tests/acceptance/e2e_settings_persistence_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_survey_autosave_test.go
+++ b/tests/acceptance/e2e_survey_autosave_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_survey_submission_test.go
+++ b/tests/acceptance/e2e_survey_submission_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_team_lead_dashboard_test.go
+++ b/tests/acceptance/e2e_team_lead_dashboard_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_team_members_test.go
+++ b/tests/acceptance/e2e_team_members_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_user_home_test.go
+++ b/tests/acceptance/e2e_user_home_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_vp_dashboard_test.go
+++ b/tests/acceptance/e2e_vp_dashboard_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/e2e_vp_dashboard_visualizations_test.go
+++ b/tests/acceptance/e2e_vp_dashboard_visualizations_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/suite_test.go
+++ b/tests/acceptance/suite_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (

--- a/tests/acceptance/test_helpers_test.go
+++ b/tests/acceptance/test_helpers_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package acceptance_test
 
 import (


### PR DESCRIPTION
## Summary

Adds SPDX-License-Identifier: Apache-2.0 headers to all source files across the repository (Go, TypeScript/TSX, JavaScript, SQL migrations, Shell scripts, and CUE files).

Closes #107

## Changes

- Added // SPDX-License-Identifier: Apache-2.0 to all .go, .ts, .tsx, .js files
- Added -- SPDX-License-Identifier: Apache-2.0 to all .sql migration files
- Added # SPDX-License-Identifier: Apache-2.0 to .sh script files
- Added /* SPDX-License-Identifier: Apache-2.0 */ to .css files
- Added // SPDX-License-Identifier: Apache-2.0 to .cue files

## Scope

195 files modified, 390 lines added. The following file types were **not** modified:
- YAML/YML configuration files (workflows, docker-compose, deploy configs)
- Markdown documentation
- Lock files, JSON configs, .gitignore, .dockerignore
- SVG/image assets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SPDX-License-Identifier: Apache-2.0` headers to all source files to standardize licensing and meet `OSS-3`. Re-synced with `main` to cover new backend Go files (interfaces, DTOs, middleware, logger) and all SQL migrations; excludes config/docs, lock/JSON, ignore files, and images.

<sup>Written for commit 4613d097062f863efe092b50e6190bcd02822ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/teams360/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

