### PR TITLE
Remove duplicate/conflicting postcss.config.mjs , Closes #100

### DIFF
--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
-
-export default config;


### PR DESCRIPTION
Removed duplicate postcss.config.mjs , Closes #100 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate `frontend/postcss.config.mjs` to eliminate conflicting PostCSS settings. It referenced `@tailwindcss/postcss` (not installed), which caused build issues with the Tailwind v4 setup.

<sup>Written for commit be8996a4b58bb11e5eae1e9a5bcb5c35e93fbc51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/teams360/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

