### PR TITLE
feat: implement theme toggle functionality and enhance dark mode styles #140

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,19 +3,155 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
   --background: #ffffff;
   --foreground: #171717;
+  --surface: #ffffff;
+  --surface-muted: #f8fafc;
+  --border: #e5e7eb;
+  --muted: #6b7280;
+  --accent: #2563eb;
+  --cardbg: #ffffff;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --background: #0d1117;
+  --foreground: #f8fafc;
+  --surface: #161b22;
+  --surface-muted: #0f172a;
+  --border: #30363d;
+  --muted: #94a3b8;
+  --accent: #58a6ff;
+  --cardbg: #111827;
+  --panel-shadow: rgba(255, 255, 255, 0.04);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+html.dark body {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+html.dark [class*='bg-white'],
+html.dark [class*='bg-slate-50'],
+html.dark [class*='bg-slate-100'] {
+  background-color: var(--surface) !important;
+}
+
+html.dark [class*='bg-gray-50'],
+html.dark [class*='bg-slate-50'] {
+  background-color: var(--surface) !important;
+}
+
+html.dark [class*='bg-gray-100'],
+html.dark [class*='bg-slate-100'] {
+  background-color: var(--surface) !important;
+}
+
+html.dark [class*='bg-gray-200'],
+html.dark [class*='bg-slate-200'] {
+  background-color: #1f2937 !important;
+}
+
+html.dark [class*='bg-gray-300'],
+html.dark [class*='bg-slate-300'] {
+  background-color: #1e293b !important;
+}
+
+html.dark [class*='text-gray-900'],
+html.dark [class*='text-gray-800'],
+html.dark [class*='text-gray-700'] {
+  color: var(--foreground) !important;
+}
+
+html.dark [class*='text-gray-600'],
+html.dark [class*='text-gray-500'],
+html.dark [class*='text-slate-500'],
+html.dark [class*='text-slate-600'] {
+  color: var(--muted) !important;
+}
+
+html.dark [class*='border-gray-200'],
+html.dark [class*='border-gray-300'],
+html.dark [class*='border-gray-400'],
+html.dark [class*='border-slate-200'],
+html.dark [class*='border-slate-300'] {
+  border-color: var(--border) !important;
+}
+
+html.dark [class*='bg-indigo-50'],
+html.dark [class*='bg-indigo-100'],
+html.dark [class*='bg-blue-50'],
+html.dark [class*='bg-blue-100'],
+html.dark [class*='bg-green-50'],
+html.dark [class*='bg-red-50'],
+html.dark [class*='bg-amber-50'] {
+  background-color: rgba(88, 166, 255, 0.12) !important;
+}
+
+html.dark [class*='bg-gradient-to-br'],
+html.dark [class*='bg-gradient-to-r'],
+html.dark [class*='bg-gradient-to-b'] {
+  background-image: linear-gradient(to bottom right, var(--surface-muted), var(--surface)) !important;
+}
+
+html.dark [class*='border-indigo-100'],
+html.dark [class*='border-indigo-200'],
+html.dark [class*='border-blue-200'],
+html.dark [class*='border-blue-100'],
+html.dark [class*='border-green-200'],
+html.dark [class*='border-red-200'],
+html.dark [class*='border-amber-200'] {
+  border-color: var(--border) !important;
+}
+
+html.dark [class*='text-indigo-600'],
+html.dark [class*='text-indigo-500'] {
+  color: var(--accent) !important;
+}
+
+html.dark .dark\:bg-gray-800 {
+  background-color: #111827 !important;
+}
+
+html.dark .dark\:text-white {
+  color: #f8fafc !important;
+}
+
+html.dark .shadow-xl,
+html.dark .shadow-lg,
+html.dark .shadow-md,
+html.dark .shadow-sm {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25), 0 4px 8px rgba(0, 0, 0, 0.2) !important;
+}
+
+html.dark ::selection {
+  background: rgba(248, 250, 252, 0.18);
+  color: var(--foreground);
+}
+
+html.dark input,
+html.dark textarea,
+html.dark select,
+html.dark button,
+html.dark optgroup,
+html.dark option,
+html.dark fieldset,
+html.dark summary {
+  color: var(--foreground) !important;
+  background-color: var(--surface) !important;
+  border-color: var(--border) !important;
+}
+
+html.dark input::placeholder,
+html.dark textarea::placeholder {
+  color: var(--muted) !important;
+  opacity: 1 !important;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,90 +39,62 @@ html.dark body {
   color: var(--foreground);
 }
 
-html.dark [class*='bg-white'],
-html.dark [class*='bg-slate-50'],
-html.dark [class*='bg-slate-100'] {
+html.dark .bg-white,
+html.dark .bg-slate-50,
+html.dark .bg-slate-100,
+html.dark .bg-gray-50,
+html.dark .bg-gray-100 {
   background-color: var(--surface) !important;
 }
 
-html.dark [class*='bg-gray-50'],
-html.dark [class*='bg-slate-50'] {
-  background-color: var(--surface) !important;
-}
-
-html.dark [class*='bg-gray-100'],
-html.dark [class*='bg-slate-100'] {
-  background-color: var(--surface) !important;
-}
-
-html.dark [class*='bg-gray-200'],
-html.dark [class*='bg-slate-200'] {
+html.dark .bg-gray-200,
+html.dark .bg-slate-200 {
   background-color: #1f2937 !important;
 }
 
-html.dark [class*='bg-gray-300'],
-html.dark [class*='bg-slate-300'] {
+html.dark .bg-gray-300,
+html.dark .bg-slate-300 {
   background-color: #1e293b !important;
 }
 
-html.dark [class*='text-gray-900'],
-html.dark [class*='text-gray-800'],
-html.dark [class*='text-gray-700'] {
+html.dark .text-gray-900,
+html.dark .text-gray-800,
+html.dark .text-gray-700 {
   color: var(--foreground) !important;
 }
 
-html.dark [class*='text-gray-600'],
-html.dark [class*='text-gray-500'],
-html.dark [class*='text-slate-500'],
-html.dark [class*='text-slate-600'] {
+html.dark .text-gray-600,
+html.dark .text-gray-500,
+html.dark .text-slate-500,
+html.dark .text-slate-600 {
   color: var(--muted) !important;
 }
 
-html.dark [class*='border-gray-200'],
-html.dark [class*='border-gray-300'],
-html.dark [class*='border-gray-400'],
-html.dark [class*='border-slate-200'],
-html.dark [class*='border-slate-300'] {
+html.dark .border-gray-200,
+html.dark .border-gray-300,
+html.dark .border-gray-400,
+html.dark .border-slate-200,
+html.dark .border-slate-300 {
   border-color: var(--border) !important;
 }
 
-html.dark [class*='bg-indigo-50'],
-html.dark [class*='bg-indigo-100'],
-html.dark [class*='bg-blue-50'],
-html.dark [class*='bg-blue-100'],
-html.dark [class*='bg-green-50'],
-html.dark [class*='bg-red-50'],
-html.dark [class*='bg-amber-50'] {
+html.dark .bg-indigo-50,
+html.dark .bg-indigo-100,
+html.dark .bg-blue-50,
+html.dark .bg-blue-100 {
   background-color: rgba(88, 166, 255, 0.12) !important;
 }
 
-html.dark [class*='bg-gradient-to-br'],
-html.dark [class*='bg-gradient-to-r'],
-html.dark [class*='bg-gradient-to-b'] {
-  background-image: linear-gradient(to bottom right, var(--surface-muted), var(--surface)) !important;
-}
-
-html.dark [class*='border-indigo-100'],
-html.dark [class*='border-indigo-200'],
-html.dark [class*='border-blue-200'],
-html.dark [class*='border-blue-100'],
-html.dark [class*='border-green-200'],
-html.dark [class*='border-red-200'],
-html.dark [class*='border-amber-200'] {
+html.dark .border-indigo-100,
+html.dark .border-indigo-200,
+html.dark .border-blue-200,
+html.dark .border-blue-100 {
   border-color: var(--border) !important;
 }
 
-html.dark [class*='text-indigo-600'],
-html.dark [class*='text-indigo-500'] {
+html.dark .text-indigo-600,
+html.dark .text-indigo-500 {
   color: var(--accent) !important;
-}
-
-html.dark .dark\:bg-gray-800 {
-  background-color: #111827 !important;
-}
-
-html.dark .dark\:text-white {
-  color: #f8fafc !important;
 }
 
 html.dark .shadow-xl,
@@ -140,7 +112,6 @@ html.dark ::selection {
 html.dark input,
 html.dark textarea,
 html.dark select,
-html.dark button,
 html.dark optgroup,
 html.dark option,
 html.dark fieldset,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,8 +3,27 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { TelemetryProvider } from "@/components/TelemetryProvider";
 import AuthGuard from "@/components/AuthGuard";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const inter = Inter({ subsets: ["latin"] });
+
+const themeScript = `
+  (function() {
+    try {
+      const storageKey = 'theme';
+      const storedTheme = window.localStorage.getItem(storageKey);
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      const theme = storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : systemTheme;
+
+      document.documentElement.setAttribute('data-theme', theme);
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+      document.documentElement.style.colorScheme = theme;
+    } catch (e) {
+      document.documentElement.setAttribute('data-theme', 'light');
+      document.documentElement.classList.remove('dark');
+    }
+  })();
+`;
 
 export const metadata: Metadata = {
   title: "Team360 Health Check",
@@ -17,8 +36,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body className={inter.className}>
+        <ThemeToggle />
         <TelemetryProvider>
           <AuthGuard>
             {children}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -21,6 +21,7 @@ const themeScript = `
     } catch (e) {
       document.documentElement.setAttribute('data-theme', 'light');
       document.documentElement.classList.remove('dark');
+      document.documentElement.style.colorScheme = 'light';
     }
   })();
 `;

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -11,8 +11,8 @@ import { Lock, User, AlertCircle, Users, LogIn } from 'lucide-react';
 export default function LoginPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-        <p className="text-gray-500">Loading...</p>
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-slate-900 dark:to-slate-950 flex items-center justify-center">
+        <p className="text-gray-500 dark:text-slate-400">Loading...</p>
       </div>
     }>
       <LoginPageContent />
@@ -101,24 +101,24 @@ function LoginPageContent() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-slate-900 dark:to-slate-950 flex items-center justify-center p-4">
       <div className="max-w-4xl w-full">
-        <div className="bg-white rounded-2xl shadow-xl overflow-hidden">
+        <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-xl overflow-hidden border border-gray-200 dark:border-slate-800">
           <div className={`grid ${isDemoMode ? 'md:grid-cols-2' : ''}`}>
             {/* Login Form */}
             <div className="p-8">
               <div className="text-center mb-8">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-indigo-100 rounded-full mb-4">
-                  <Lock className="w-8 h-8 text-indigo-600" />
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-indigo-100 dark:bg-indigo-950/70 rounded-full mb-4">
+                  <Lock className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
                 </div>
-                <h1 className="text-3xl font-bold text-gray-900">Team Health Check</h1>
-                <p className="text-gray-500 mt-2">Sign in to continue</p>
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">Team Health Check</h1>
+                <p className="text-gray-500 dark:text-slate-400 mt-2">Sign in to continue</p>
               </div>
 
               {sessionExpired && (
                 <div
                   data-testid="session-expired-banner"
-                  className="mb-6 flex items-center gap-2 text-amber-700 text-sm bg-amber-50 border border-amber-200 p-3 rounded-lg"
+                  className="mb-6 flex items-center gap-2 text-amber-700 dark:text-amber-300 text-sm bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 p-3 rounded-lg"
                 >
                   <AlertCircle className="w-4 h-4 flex-shrink-0" />
                   <span>Your session has expired. Please log in again.</span>
@@ -127,7 +127,7 @@ function LoginPageContent() {
 
               <form onSubmit={handleLogin} className="space-y-6">
                 <div>
-                  <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="username" className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
                     Username
                   </label>
                   <div className="relative">
@@ -137,7 +137,7 @@ function LoginPageContent() {
                       type="text"
                       value={username}
                       onChange={(e) => setUsername(e.target.value)}
-                      className="w-full px-4 py-3 pl-10 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-indigo-500 focus:border-transparent placeholder:text-gray-400"
+                      className="w-full px-4 py-3 pl-10 border border-gray-300 dark:border-slate-700 rounded-lg text-gray-900 dark:text-slate-100 bg-white dark:bg-slate-800 focus:ring-2 focus:ring-indigo-500 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-slate-500"
                       placeholder="Enter username"
                       required
                     />
@@ -146,7 +146,7 @@ function LoginPageContent() {
                 </div>
 
                 <div>
-                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
                     Password
                   </label>
                   <div className="relative">
@@ -156,7 +156,7 @@ function LoginPageContent() {
                       type="password"
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
-                      className="w-full px-4 py-3 pl-10 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-indigo-500 focus:border-transparent placeholder:text-gray-400"
+                      className="w-full px-4 py-3 pl-10 border border-gray-300 dark:border-slate-700 rounded-lg text-gray-900 dark:text-slate-100 bg-white dark:bg-slate-800 focus:ring-2 focus:ring-indigo-500 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-slate-500"
                       placeholder="Enter password"
                       required
                     />
@@ -165,7 +165,7 @@ function LoginPageContent() {
                 </div>
 
                 {error && (
-                  <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-3 rounded-lg" data-testid="login-error">
+                  <div className="flex items-center gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/40 p-3 rounded-lg" data-testid="login-error">
                     <AlertCircle className="w-4 h-4" />
                     <span>{error}</span>
                   </div>
@@ -182,14 +182,14 @@ function LoginPageContent() {
               {ssoConfig && (
                 <>
                   <div className="flex items-center gap-3 mt-6">
-                    <div className="flex-1 h-px bg-gray-200" />
-                    <span className="text-sm text-gray-400">or</span>
-                    <div className="flex-1 h-px bg-gray-200" />
+                    <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
+                    <span className="text-sm text-gray-400 dark:text-slate-500">or</span>
+                    <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
                   </div>
                   <button
                     onClick={handleSSOLogin}
                     disabled={ssoLoading}
-                    className="w-full mt-4 flex items-center justify-center gap-2 border border-gray-300 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-50 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                    className="w-full mt-4 flex items-center justify-center gap-2 border border-gray-300 dark:border-slate-700 text-gray-700 dark:text-slate-300 bg-white dark:bg-slate-800 py-3 rounded-lg font-semibold hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                   >
                     <LogIn className="w-5 h-5" />
                     {ssoLoading ? 'Redirecting\u2026' : 'Sign in with SSO'}
@@ -199,60 +199,60 @@ function LoginPageContent() {
             </div>
 
             {/* Demo Credentials Info - only shown when APP_ENV=demo */}
-            {isDemoMode && <div className="bg-gradient-to-br from-indigo-50 to-blue-50 p-8 border-l">
-              <h3 className="text-lg font-semibold text-gray-900 mb-6 flex items-center gap-2">
-                <Users className="w-5 h-5 text-indigo-600" />
+            {isDemoMode && <div className="bg-gradient-to-br from-indigo-50 to-blue-50 dark:from-slate-800 dark:to-slate-900 p-8 border-l dark:border-slate-800">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-6 flex items-center gap-2">
+                <Users className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
                 Demo Login Credentials
               </h3>
 
               <div className="space-y-4">
-                <div className="bg-white rounded-lg p-4 border border-indigo-100">
-                  <h4 className="font-semibold text-gray-900 mb-3 text-sm">Organizational Hierarchy</h4>
+                <div className="bg-white dark:bg-slate-800 rounded-lg p-4 border border-indigo-100 dark:border-slate-700">
+                  <h4 className="font-semibold text-gray-900 dark:text-slate-100 mb-3 text-sm">Organizational Hierarchy</h4>
                   <div className="space-y-2 text-sm">
                     <div className="flex justify-between items-center py-1">
-                      <span className="text-gray-700 font-medium">VP:</span>
-                      <code className="bg-gray-200 px-2 py-1 rounded text-xs font-mono text-gray-800">vp/demo</code>
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">VP:</span>
+                      <code className="bg-gray-200 dark:bg-slate-700 px-2 py-1 rounded text-xs font-mono text-gray-800 dark:text-slate-200">vp/demo</code>
                     </div>
                     <div className="flex justify-between items-center py-1">
-                      <span className="text-gray-700 font-medium">Director:</span>
-                      <code className="bg-gray-200 px-2 py-1 rounded text-xs font-mono text-gray-800">director1/demo</code>
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">Director:</span>
+                      <code className="bg-gray-200 dark:bg-slate-700 px-2 py-1 rounded text-xs font-mono text-gray-800 dark:text-slate-200">director1/demo</code>
                     </div>
                     <div className="flex justify-between items-center py-1">
-                      <span className="text-gray-700 font-medium">Manager:</span>
-                      <code className="bg-gray-200 px-2 py-1 rounded text-xs font-mono text-gray-800">manager1/demo</code>
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">Manager:</span>
+                      <code className="bg-gray-200 dark:bg-slate-700 px-2 py-1 rounded text-xs font-mono text-gray-800 dark:text-slate-200">manager1/demo</code>
                     </div>
                     <div className="flex justify-between items-center py-1">
-                      <span className="text-gray-700 font-medium">Team Lead:</span>
-                      <code className="bg-gray-200 px-2 py-1 rounded text-xs font-mono text-gray-800">teamlead1/demo</code>
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">Team Lead:</span>
+                      <code className="bg-gray-200 dark:bg-slate-700 px-2 py-1 rounded text-xs font-mono text-gray-800 dark:text-slate-200">teamlead1/demo</code>
                     </div>
                     <div className="flex justify-between items-center py-1">
-                      <span className="text-gray-700 font-medium">Team Member:</span>
-                      <code className="bg-gray-200 px-2 py-1 rounded text-xs font-mono text-gray-800">demo/demo</code>
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">Team Member:</span>
+                      <code className="bg-gray-200 dark:bg-slate-700 px-2 py-1 rounded text-xs font-mono text-gray-800 dark:text-slate-200">demo/demo</code>
                     </div>
-                    <div className="flex justify-between items-center py-1 border-t border-gray-200 mt-2 pt-2">
-                      <span className="text-gray-700 font-medium">Admin:</span>
-                      <code className="bg-red-100 px-2 py-1 rounded text-xs font-mono text-red-800 font-semibold">admin/admin</code>
+                    <div className="flex justify-between items-center py-1 border-t border-gray-200 dark:border-slate-700 mt-2 pt-2">
+                      <span className="text-gray-700 dark:text-slate-300 font-medium">Admin:</span>
+                      <code className="bg-red-100 dark:bg-red-950/60 px-2 py-1 rounded text-xs font-mono text-red-800 dark:text-red-300 font-semibold">admin/admin</code>
                     </div>
                   </div>
                 </div>
 
-                <div className="bg-blue-50 rounded-lg p-4 border border-blue-200">
-                  <p className="text-xs text-blue-700 leading-relaxed">
+                <div className="bg-blue-50 dark:bg-slate-800 rounded-lg p-4 border border-blue-200 dark:border-slate-700">
+                  <p className="text-xs text-blue-700 dark:text-blue-300 leading-relaxed">
                     <strong className="block mb-2">All Accounts:</strong>
-                    {'\u2022'} All passwords are <strong>&quot;demo&quot;</strong> except admin<br/>
-                    {'\u2022'} Use director1, director2, manager1-3, teamlead1-5<br/>
-                    {'\u2022'} Or team members: alice, bob, carol, david, eve<br/>
-                    {'\u2022'} Admin password is <strong>&quot;admin&quot;</strong>
+                    {'•'} All passwords are <strong>&quot;demo&quot;</strong> except admin<br/>
+                    {'•'} Use director1, director2, manager1-3, teamlead1-5<br/>
+                    {'•'} Or team members: alice, bob, carol, david, eve<br/>
+                    {'•'} Admin password is <strong>&quot;admin&quot;</strong>
                   </p>
                 </div>
 
-                <div className="bg-green-50 rounded-lg p-4 border border-green-200">
-                  <p className="text-xs text-green-700 leading-relaxed">
+                <div className="bg-green-50 dark:bg-slate-800 rounded-lg p-4 border border-green-200 dark:border-slate-700">
+                  <p className="text-xs text-green-700 dark:text-green-300 leading-relaxed">
                     <strong className="block mb-1">What Each User Sees:</strong>
-                    {'\u2022'} <strong>VP/Directors/Managers:</strong> Manager Dashboard<br/>
-                    {'\u2022'} <strong>Team Leads:</strong> Team Dashboard<br/>
-                    {'\u2022'} <strong>Team Members:</strong> Member Home (Survey History)<br/>
-                    {'\u2022'} <strong>Admin:</strong> System Configuration
+                    {'•'} <strong>VP/Directors/Managers:</strong> Manager Dashboard<br/>
+                    {'•'} <strong>Team Leads:</strong> Team Dashboard<br/>
+                    {'•'} <strong>Team Members:</strong> Member Home (Survey History)<br/>
+                    {'•'} <strong>Admin:</strong> System Configuration
                   </p>
                 </div>
               </div>

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'theme';
+
+type Theme = 'light' | 'dark';
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+  return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const initialTheme = getStoredTheme() ?? getSystemTheme();
+    setTheme(initialTheme);
+    document.documentElement.setAttribute('data-theme', initialTheme);
+    document.documentElement.classList.toggle('dark', initialTheme === 'dark');
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((currentTheme) => (currentTheme === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="fixed right-4 top-4 z-50 rounded-full border border-gray-300 bg-white/90 px-3 py-2 text-sm font-medium text-gray-800 shadow-sm backdrop-blur transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900/90 dark:text-gray-100 dark:hover:bg-gray-800"
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+    </button>
+  );
+}

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -11,7 +11,28 @@ function getSystemTheme(): Theme {
     return 'light';
   }
 
+  if (typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getBootstrappedTheme(): Theme {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+
+  const bootstrappedTheme = document.documentElement.getAttribute('data-theme');
+  if (bootstrappedTheme === 'dark' || bootstrappedTheme === 'light') {
+    return bootstrappedTheme;
+  }
+
+  if (document.documentElement.classList.contains('dark')) {
+    return 'dark';
+  }
+
+  return getSystemTheme();
 }
 
 function getStoredTheme(): Theme | null {
@@ -19,24 +40,49 @@ function getStoredTheme(): Theme | null {
     return null;
   }
 
-  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
-  return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+  try {
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+    return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+  document.documentElement.style.colorScheme = theme;
+}
+
+function persistTheme(theme: Theme): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // Ignore storage errors in browser privacy modes.
+  }
 }
 
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
-    const initialTheme = getStoredTheme() ?? getSystemTheme();
-    setTheme(initialTheme);
-    document.documentElement.setAttribute('data-theme', initialTheme);
-    document.documentElement.classList.toggle('dark', initialTheme === 'dark');
+    const resolvedTheme = getStoredTheme() ?? getBootstrappedTheme();
+    setTheme(resolvedTheme);
+    applyTheme(resolvedTheme);
+    persistTheme(resolvedTheme);
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-    window.localStorage.setItem(STORAGE_KEY, theme);
+    applyTheme(theme);
+    persistTheme(theme);
   }, [theme]);
 
   const toggleTheme = () => {
@@ -47,8 +93,9 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggleTheme}
-      className="fixed right-4 top-4 z-50 rounded-full border border-gray-300 bg-white/90 px-3 py-2 text-sm font-medium text-gray-800 shadow-sm backdrop-blur transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900/90 dark:text-gray-100 dark:hover:bg-gray-800"
+      className="fixed right-4 bottom-4 z-50 rounded-full border border-gray-300 bg-white/90 px-3 py-2 text-sm font-medium text-gray-800 shadow-sm backdrop-blur transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900/90 dark:text-gray-100 dark:hover:bg-gray-800"
       aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      aria-pressed={theme === 'dark'}
     >
       {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
     </button>

--- a/frontend/components/__tests__/ThemeToggle.test.tsx
+++ b/frontend/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import ThemeToggle from '../ThemeToggle';
+
+const STORAGE_KEY = 'theme';
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('dark') ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the stored theme preference on initial render', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'dark');
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('falls back to the system theme when no preference is stored', async () => {
+    mockMatchMedia(true);
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+  });
+
+  it('uses a stable initial render even when the document is already bootstrapped to dark mode', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    document.documentElement.classList.add('dark');
+    document.documentElement.style.colorScheme = 'dark';
+
+    render(<ThemeToggle />);
+
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toHaveTextContent('☀️ Light');
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps working when storage access throws', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+
+    expect(() => render(<ThemeToggle />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+
+  it('updates the document theme attributes and persisted state when toggled', async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe('dark');
+    });
+
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a theme toggle with persisted preference and server-safe initial theme to deliver a consistent dark mode across the app. Updates login page and global styles for better contrast and polish in dark mode.

- **New Features**
  - Added `ThemeToggle` (bottom-right) to switch light/dark, storing preference in `localStorage` and syncing `data-theme` and `html.dark`.
  - Injected an inline theme script in `layout.tsx` and enabled `suppressHydrationWarning` to set the theme before hydration and prevent flash.
  - Enabled `darkMode: 'class'` and expanded `globals.css` with variables and dark overrides for surfaces, text, borders, shadows, gradients, inputs, and selection.
  - Updated login page styles to fully support dark mode (backgrounds, text, borders, alerts, and demo info panel).
  - Added tests for `ThemeToggle` covering bootstrapped state, system preference fallback, persistence, and storage errors.

<sup>Written for commit 4f767a5a3337bcebafc6c5960f4e1a884471c454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/teams360/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

