### PR TITLE
Fix/branding rename pr 137

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# Team360 Environment Variables
+# Team Health Check Environment Variables
 # Copy this file to .env and update with your values
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,18 +333,18 @@ Remember: **Claude Flow coordinates, Claude Code creates!**
 ---
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# PROJECT DOCUMENTATION: Team360 Health Check Application
+# PROJECT DOCUMENTATION: Team Health Check Health Check Application
 # ═══════════════════════════════════════════════════════════════════════════════
 
 ## Project Overview
 
-Team360 is an open-source (Apache 2.0 licensed) web application based on Spotify's Squad Health Check Model, enhanced with organizational flexibility and hierarchical management capabilities.
+Team Health Check is an open-source (Apache 2.0 licensed) web application based on Spotify's Squad Health Check Model, enhanced with organizational flexibility and hierarchical management capabilities.
 
 **Architecture**: Next.js 15 frontend with Go backend (Gin framework), following Domain-Driven Design (DDD) principles and Test-Driven Development (TDD) practices.
 
 ### Purpose & Philosophy
 
-Inspired by [Spotify's Squad Health Check Model](https://engineering.atspotify.com/2014/09/squad-health-check-model), Team360 helps teams systematically assess their working environment and identify improvement areas through structured self-reflection.
+Inspired by [Spotify's Squad Health Check Model](https://engineering.atspotify.com/2014/09/squad-health-check-model), Team Health Check helps teams systematically assess their working environment and identify improvement areas through structured self-reflection.
 
 **Core Philosophy** (from Spotify):
 - Teams are intrinsically motivated and want to succeed
@@ -357,7 +357,7 @@ Inspired by [Spotify's Squad Health Check Model](https://engineering.atspotify.c
 
 ### Enhancements Over Original Spotify Model
 
-Team360 extends the original concept with enterprise-ready features:
+Team Health Check extends the original concept with enterprise-ready features:
 
 1. **Hierarchical Organization Support**: Multi-level hierarchy (VP → Director → Manager → Team Lead → Team Member) with supervisor chains
 2. **Configurable Dimensions**: 11 health dimensions (expanded from Spotify's ~8), fully customizable
@@ -365,7 +365,7 @@ Team360 extends the original concept with enterprise-ready features:
 4. **Assessment Periods**: Track trends across defined periods (e.g., "2024 - 1st Half")
 5. **Role-Based Access Control**: Granular permissions system for different organizational levels
 6. **Aggregated Insights**: Roll-up views for managers and executives across multiple teams
-7. **Digital-First**: While Spotify emphasizes face-to-face workshops, Team360 enables distributed teams to participate asynchronously
+7. **Digital-First**: While Spotify emphasizes face-to-face workshops, Team Health Check enables distributed teams to participate asynchronously
 
 Built with Next.js 15, TypeScript, and Tailwind CSS for modern, maintainable development.
 
@@ -530,7 +530,7 @@ npm install --force @next/swc-darwin-arm64  # If still having issues
 
 ## KubeVela + CNPG Deployment (Kubernetes)
 
-Team360 supports deployment to Kubernetes via **KubeVela** (Open Application Model) with **CloudNativePG** for production-grade PostgreSQL. This is an alternative to the existing Helm charts in `helm/teams360/`.
+Team Health Check supports deployment to Kubernetes via **KubeVela** (Open Application Model) with **CloudNativePG** for production-grade PostgreSQL. This is an alternative to the existing Helm charts in `helm/teams360/`.
 
 ### Prerequisites
 
@@ -614,7 +614,7 @@ After `make kubevela-deploy-all`, verify:
 
 ### Testing Philosophy: TRUE Outer-Loop TDD
 
-Team360 follows **TRUE Outer-Loop Test-Driven Development** principles:
+Team Health Check follows **TRUE Outer-Loop Test-Driven Development** principles:
 
 1. **Write E2E tests FIRST** that interact through the UI like a real user would
 2. **Let tests drive implementation** - tests should fail until feature is complete
@@ -624,7 +624,7 @@ Team360 follows **TRUE Outer-Loop Test-Driven Development** principles:
 
 ### Test Organization
 
-Team360 uses a three-tier testing pyramid:
+Team Health Check uses a three-tier testing pyramid:
 
 ```
 /tests/acceptance/              # E2E/Acceptance Tests (Playwright, full stack)
@@ -948,9 +948,9 @@ Located in `frontend/lib/types.ts`:
    - `Team`: Has supervisorChain (full chain of supervisors), members, cadence (survey frequency)
 
 3. **Health Checks**:
-   - `HealthDimension`: 11 dimensions based on Spotify's model with Team360 enhancements:
+   - `HealthDimension`: 11 dimensions based on Spotify's model with Team Health Check enhancements:
      - **From Spotify's model**: Mission, Delivering Value, Speed, Fun, Health of Codebase, Learning, Support, Pawns or Players
-     - **Team360 additions**: Easy to Release, Suitable Process, Teamwork
+     - **Team Health Check additions**: Easy to Release, Suitable Process, Teamwork
      - Each dimension has goodDescription/badDescription for clarity (e.g., "We deliver great stuff!" vs "We deliver crap")
      - Dimensions can be enabled/disabled and weighted via isActive and weight properties
    - `HealthCheckSession`: User's responses to health check, includes assessmentPeriod (e.g., "2024 - 1st Half")
@@ -1111,11 +1111,11 @@ When adding features:
 
 ## Open Source Philosophy
 
-Team360 is released under the **Apache 2.0 license** to benefit organizations worldwide. The goal is to make structured team health assessment accessible to any organization, regardless of size or resources.
+Team Health Check is released under the **Apache 2.0 license** to benefit organizations worldwide. The goal is to make structured team health assessment accessible to any organization, regardless of size or resources.
 
 ### Design Principles
 
-When contributing or extending Team360, keep these principles in mind:
+When contributing or extending Team Health Check, keep these principles in mind:
 
 1. **Support, Not Surveillance**: Features should help teams improve, never be weaponized for performance reviews
 2. **Flexibility First**: Organizations differ - support customization (dimensions, cadences, hierarchies)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ Remember: **Claude Flow coordinates, Claude Code creates!**
 ---
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# PROJECT DOCUMENTATION: Team Health Check Health Check Application
+# PROJECT DOCUMENTATION: Team Health Check Application
 # ═══════════════════════════════════════════════════════════════════════════════
 
 ## Project Overview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ proposals); Discussions are best for *open-ended* conversations.
 ### Reporting Bugs
 
 Before opening a new issue, please check the
-[issue tracker](https://github.com/guidewire-oss/Team Health Check/issues) to see if
+[issue tracker](https://github.com/guidewire-oss/teams360/issues) to see if
 it's already reported. When opening a bug report, include as many details as
 possible:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to Teams360
+# Contributing to Team Health Check
 
-First off, thank you for considering contributing to Teams360! It's people like
-you who make Teams360 a useful tool for teams everywhere. Any contribution you
+First off, thank you for considering contributing to Team Health Check! It's people like
+you who make Team Health Check a useful tool for teams everywhere. Any contribution you
 make — code, docs, bug reports, enhancement ideas — is greatly appreciated.
 
 ## Code of Conduct
 
 While we are not a CNCF project, we fully support and endorse its general
-principles. As an extension, Teams360 follows their
+principles. As an extension, Team Health Check follows their
 [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 that we expect project participants to adhere to. Please read the full text so
 you understand what actions will and will not be tolerated.
@@ -17,7 +17,7 @@ you understand what actions will and will not be tolerated.
 ### Starting a Discussion
 
 Have a question, an idea that isn't fully formed, or want to share how your
-team is using Teams360? Use
+team is using Team Health Check? Use
 [GitHub Discussions](https://github.com/guidewire-oss/teams360/discussions)
 rather than opening an issue:
 
@@ -25,7 +25,7 @@ rather than opening an issue:
 - **Ideas** — early-stage enhancement thinking that hasn't crystallised into a
   concrete proposal yet
 - **Show and tell** — screenshots, custom dimension configs, or workflows your
-  team has built around Teams360
+  team has built around Team Health Check
 
 Issues are best for *actionable* items (bug reports, concrete enhancement
 proposals); Discussions are best for *open-ended* conversations.
@@ -33,7 +33,7 @@ proposals); Discussions are best for *open-ended* conversations.
 ### Reporting Bugs
 
 Before opening a new issue, please check the
-[issue tracker](https://github.com/guidewire-oss/teams360/issues) to see if
+[issue tracker](https://github.com/guidewire-oss/Team Health Check/issues) to see if
 it's already reported. When opening a bug report, include as many details as
 possible:
 
@@ -66,7 +66,7 @@ labels.
 
 ## Development Setup
 
-Teams360 is a Go (Gin) backend + Next.js frontend with a PostgreSQL database.
+Team Health Check is a Go (Gin) backend + Next.js frontend with a PostgreSQL database.
 The Makefile orchestrates everything; the most useful targets:
 
 ```bash
@@ -110,7 +110,7 @@ certifying that you wrote or otherwise have the right to submit the code under
 the project's Apache 2.0 license. This is signified by adding a `Signed-off-by`
 line to your commits (`git commit -s`).
 
-Once the pull request is opened, a Teams360 maintainer will review your
+Once the pull request is opened, a Team Health Check maintainer will review your
 changes. CI must be green before merge. If everything is good, your PR will be
 merged into `main`.
 
@@ -135,5 +135,5 @@ merged into `main`.
 
 ## License
 
-By contributing to Teams360, you agree that your contributions will be licensed
+By contributing to Team Health Check, you agree that your contributions will be licensed
 under the [Apache License 2.0](LICENSE).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # =============================================================================
-# Team360 Unified Image — Frontend (static export) + Backend (Go API)
+# Team Health Check Unified Image — Frontend (static export) + Backend (Go API)
 # Uses --platform=$BUILDPLATFORM so npm/go builds run natively (no QEMU)
 # =============================================================================
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ FRONTEND_PID := $(PID_DIR)/frontend.pid
 # =============================================================================
 
 help: ## Show this help message
-	@echo "$(BOLD)Team360 - Squad Health Check Application$(RESET)"
+	@echo "$(BOLD)Team Health Check - Squad Health Check Application$(RESET)"
 	@echo "Full-stack application with Go backend and Next.js frontend"
 	@echo ""
 	@echo "$(BOLD)$(CYAN)Quick Start:$(RESET) make run"
@@ -122,7 +122,7 @@ _start-backend:
 
 _print-banner:
 	@echo ""
-	@echo "$(BOLD)$(CYAN)Starting Team360...$(RESET)"
+	@echo "$(BOLD)$(CYAN)Starting Team Health Check...$(RESET)"
 	@echo ""
 	@echo "  $(CYAN)Frontend:$(RESET) http://localhost:3000"
 	@echo "  $(CYAN)Backend:$(RESET)  http://localhost:8080"
@@ -394,7 +394,7 @@ docker-run: docker-build ## Run in Docker containers
 # =============================================================================
 
 status: ## Show project status
-	@echo "$(BOLD)$(CYAN)Team360 Project Status$(RESET)"
+	@echo "$(BOLD)$(CYAN)Team Health Check Project Status$(RESET)"
 	@echo ""
 	@echo "$(CYAN)Frontend (Next.js 15 + TypeScript):$(RESET)"
 	@echo "  Location: ./frontend"
@@ -464,7 +464,7 @@ otel-logs: ## View OTel collector logs
 
 run-with-otel: _ensure-deps _ensure-db _kill-servers _ensure-otel ## Run full app with telemetry enabled
 	@echo ""
-	@echo "$(BOLD)$(CYAN)Starting Team360 with OpenTelemetry...$(RESET)"
+	@echo "$(BOLD)$(CYAN)Starting Team Health Check with OpenTelemetry...$(RESET)"
 	@echo ""
 	@echo "  $(CYAN)Frontend:$(RESET)   http://localhost:3000"
 	@echo "  $(CYAN)Backend:$(RESET)    http://localhost:8080"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Root Makefile for Team360 Monorepo
+# Root Makefile for Team Health Check Monorepo
 # Orchestrates both Frontend (Next.js/TypeScript) and Backend (Go/Gin)
 #
 # Quick Start: make run

--- a/Makefile.kubevela
+++ b/Makefile.kubevela
@@ -166,7 +166,7 @@ kubevela-status: ## [KubeVela] Show application status, pods, services, ingress
 
 kubevela-deploy-all: ## [KubeVela] Full pipeline: cluster -> prereqs -> build -> deploy
 	@echo "$(BOLD)$(CYAN)========================================$(RESET)"
-	@echo "$(BOLD)$(CYAN)  Team360 KubeVela Full Deployment$(RESET)"
+	@echo "$(BOLD)$(CYAN)  Team Health Check KubeVela Full Deployment$(RESET)"
 	@echo "$(BOLD)$(CYAN)========================================$(RESET)"
 	@echo ""
 	$(MAKE) kubevela-k3d-create

--- a/Makefile.kubevela
+++ b/Makefile.kubevela
@@ -1,5 +1,5 @@
 # =============================================================================
-# Team360 KubeVela + CNPG Deployment Automation
+# Team Health Check KubeVela + CNPG Deployment Automation
 # Included from root Makefile via: -include Makefile.kubevela
 #
 # Full pipeline:  make kubevela-deploy-all

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Team360 Health Check
+# Team Health Check
 
 [![CI](https://github.com/guidewire-oss/teams360/actions/workflows/ci.yml/badge.svg)](https://github.com/guidewire-oss/teams360/actions/workflows/ci.yml)
 [![Security](https://github.com/guidewire-oss/teams360/actions/workflows/security.yml/badge.svg)](https://github.com/guidewire-oss/teams360/actions/workflows/security.yml)
@@ -9,9 +9,9 @@
 
 An open-source team health assessment platform inspired by [Spotify's Squad Health Check Model](https://engineering.atspotify.com/2014/09/squad-health-check-model/), designed to help organizations systematically improve team well-being and effectiveness.
 
-## What is Team360?
+## What is Team Health Check?
 
-Team360 enables teams to regularly assess their working environment across multiple dimensions (mission clarity, delivery speed, code health, fun, etc.) using a simple red/yellow/green scoring system. The platform aggregates these assessments to help managers and executives identify areas needing support and track improvements over time.
+Team Health Check enables teams to regularly assess their working environment across multiple dimensions (mission clarity, delivery speed, code health, fun, etc.) using a simple red/yellow/green scoring system. The platform aggregates these assessments to help managers and executives identify areas needing support and track improvements over time.
 
 ### Core Philosophy
 
@@ -53,7 +53,7 @@ Monitor your team's health with detailed breakdowns and individual response trac
 
 ### One-Command Setup
 
-The easiest way to run Team360 locally:
+The easiest way to run Team Health Check locally:
 
 ```bash
 git clone https://github.com/anthropics/teams360.git
@@ -141,7 +141,7 @@ Use these demo credentials to explore different user roles:
 
 ### Step 1: Initial Setup (Admin)
 
-Before teams can start using Team360, an administrator needs to configure the organization structure. Log in as an admin (`admin/admin`) and navigate to the Admin Dashboard (`/admin`).
+Before teams can start using Team Health Check, an administrator needs to configure the organization structure. Log in as an admin (`admin/admin`) and navigate to the Admin Dashboard (`/admin`).
 
 #### Configure Hierarchy Levels
 
@@ -196,7 +196,7 @@ Create user accounts for everyone who will participate in health checks.
 
 ### Step 2: Establish Assessment Periods
 
-Team360 automatically determines assessment periods based on the calendar:
+Team Health Check automatically determines assessment periods based on the calendar:
 - **January - June**: Surveys contribute to "Previous Year - 2nd Half" (reflecting on the period just ended)
 - **July - December**: Surveys contribute to "Current Year - 1st Half"
 
@@ -340,7 +340,7 @@ teams360/
 
 ### Using Make Commands
 
-Team360 uses a comprehensive Makefile for common development tasks. See [docs/MAKEFILE.md](docs/MAKEFILE.md) for full documentation.
+Team Health Check uses a comprehensive Makefile for common development tasks. See [docs/MAKEFILE.md](docs/MAKEFILE.md) for full documentation.
 
 ```bash
 # Quick start - run the full application
@@ -385,7 +385,7 @@ ginkgo -r ./...           # Run Ginkgo tests
 
 ### Testing
 
-Team360 uses a comprehensive testing strategy:
+Team Health Check uses a comprehensive testing strategy:
 
 | Test Type | Command | Description |
 |-----------|---------|-------------|
@@ -493,16 +493,16 @@ OAUTH_REDIRECT_URI=http://localhost:3000/auth/callback
 
 ### Configuring SSO (OIDC / OAuth 2.0)
 
-Team360 supports single sign-on via any OIDC-compliant provider (Keycloak, Okta, Auth0, Google, Azure AD, etc.) using the **Authorization Code + PKCE** flow. Username/password login continues to work alongside SSO.
+Team Health Check supports single sign-on via any OIDC-compliant provider (Keycloak, Okta, Auth0, Google, Azure AD, etc.) using the **Authorization Code + PKCE** flow. Username/password login continues to work alongside SSO.
 
 #### How it works
 
-1. Register Team360 as a **Single Page Application (public client)** in your provider — no client secret is needed.
+1. Register Team Health Check as a **Single Page Application (public client)** in your provider — no client secret is needed.
 2. Add `http://localhost:3000/auth/callback` (or your production URL) as an allowed redirect URI.
 3. Set the environment variables listed above in both `frontend/.env.local` and `backend/.env`.
 4. Restart both servers. A **Sign in with SSO** button will appear on the login page.
 
-When a user signs in via SSO, Team360 extracts their `email` from the provider's ID token and looks up the matching user in the database. The user must already exist — Team360 does not auto-create accounts from SSO logins.
+When a user signs in via SSO, Team Health Check extracts their `email` from the provider's ID token and looks up the matching user in the database. The user must already exist — Team Health Check does not auto-create accounts from SSO logins.
 
 #### Provider setup quick reference
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-# Backend Makefile for Team360 Go API
+# Backend Makefile for Team Health Check Go API
 # Follows DDD architecture and TDD practices with Ginkgo/Gomega
 
 .PHONY: help install run build test test-verbose test-coverage clean lint fmt vet tidy
@@ -25,7 +25,7 @@ GINKGO=ginkgo
 GINKGO_FLAGS=-v --race --randomize-all --randomize-suites --fail-on-pending --trace
 
 help: ## Display this help message
-	@echo "Team360 Backend - Go API with Gin, DDD, and TDD"
+	@echo "Team Health Check Backend - Go API with Gin, DDD, and TDD"
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""
@@ -47,15 +47,15 @@ tidy: ## Tidy go.mod and go.sum
 	$(GOMOD) tidy
 
 run: ## Run the API server (development mode)
-	@echo "Starting Team360 API server..."
+	@echo "Starting Team Health Check API server..."
 	$(GOCMD) run $(MAIN_PATH)/main.go
 
 dev: ## Run the API server with hot reload (requires air)
-	@echo "Starting Team360 API server with hot reload..."
+	@echo "Starting Team Health Check API server with hot reload..."
 	air
 
 build: ## Build the API binary
-	@echo "Building Team360 API..."
+	@echo "Building Team Health Check API..."
 	@mkdir -p bin
 	$(GOBUILD) -o $(BINARY_PATH) $(MAIN_PATH)/main.go
 	@echo "Build complete: $(BINARY_PATH)"
@@ -136,7 +136,7 @@ otel-logs: ## View OTel collector logs
 	@docker compose -f deploy/docker-compose.observability.yaml logs -f otel-collector
 
 run-with-otel: ## Run API server with telemetry enabled
-	@echo "Starting Team360 API with OpenTelemetry enabled..."
+	@echo "Starting Team Health Check API with OpenTelemetry enabled..."
 	@echo "Make sure observability stack is running (make otel-start)"
 	@echo ""
 	OTEL_ENABLED=true $(GOCMD) run $(MAIN_PATH)/main.go

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Team360 Backend API
+# Team Health Check Backend API
 
-Go backend for Team360 Squad Health Check application, built with Gin framework following Domain-Driven Design (DDD) principles and Test-Driven Development (TDD) practices.
+Go backend for Team Health Check Squad Health Check application, built with Gin framework following Domain-Driven Design (DDD) principles and Test-Driven Development (TDD) practices.
 
 ## Architecture
 

--- a/backend/application/services/notification_service.go
+++ b/backend/application/services/notification_service.go
@@ -76,7 +76,7 @@ func (n *NotificationService) SendIndividualSurveyEmail(ctx context.Context, ses
 	}
 
 	htmlBody := email.RenderIndividualSurveyEmail(data)
-	subject := "Teams360 — Your Health Check Submission (" + tm.Name + ")"
+	subject := "Team Health Check — Your Health Check Submission (" + tm.Name + ")"
 
 	if err := n.sender.SendHTML(ctx, usr.Email, subject, htmlBody); err != nil {
 		log.WithError(err).WithField("to", usr.Email).Warn("notification: failed to send individual survey email")
@@ -132,7 +132,7 @@ func (n *NotificationService) sendTeamSummaryEmail(ctx context.Context, session 
 	}
 
 	htmlBody := email.RenderTeamSummaryEmail(data)
-	subject := "Teams360 — Post-Workshop Summary (" + tm.Name + ", " + session.AssessmentPeriod + ")"
+	subject := "Team Health Check — Post-Workshop Summary (" + tm.Name + ", " + session.AssessmentPeriod + ")"
 
 	if err := n.sender.SendHTML(ctx, *tm.DistributionListEmail, subject, htmlBody); err != nil {
 		log.WithError(err).WithField("to", *tm.DistributionListEmail).Warn("notification: failed to send team summary email")

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -302,7 +302,7 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		log.WithField("port", port).Info("starting Team360 API server")
+		log.WithField("port", port).Info("starting Team Health Check API server")
 		if err := router.Run(":" + port); err != nil {
 			log.WithError(err).Fatal("failed to start server")
 		}

--- a/backend/deploy/grafana/provisioning/dashboards/dashboards.yaml
+++ b/backend/deploy/grafana/provisioning/dashboards/dashboards.yaml
@@ -4,9 +4,9 @@
 apiVersion: 1
 
 providers:
-  - name: 'Teams360 Dashboards'
+  - name: 'Team Health Check Dashboards'
     orgId: 1
-    folder: 'Teams360'
+    folder: 'Team Health Check'
     folderUid: 'teams360'
     type: file
     disableDeletion: false

--- a/backend/deploy/grafana/provisioning/dashboards/json/product-analytics.json
+++ b/backend/deploy/grafana/provisioning/dashboards/json/product-analytics.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Team360 Product Analytics Dashboard - Track user engagement, survey metrics, and team health",
+  "description": "Team Health Check Product Analytics Dashboard - Track user engagement, survey metrics, and team health",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -431,7 +431,7 @@
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "",
-  "title": "Team360 Product Analytics",
+  "title": "Team Health Check Product Analytics",
   "uid": "team360-product-analytics",
   "version": 1,
   "weekStart": ""

--- a/backend/infrastructure/email/ses_service.go
+++ b/backend/infrastructure/email/ses_service.go
@@ -111,10 +111,10 @@ func (s *SESEmailService) SendHTML(ctx context.Context, to, subject, htmlBody st
 
 // SendPasswordResetEmail sends a password reset email via SES.
 func (s *SESEmailService) SendPasswordResetEmail(ctx context.Context, emailAddr, resetToken string) error {
-	subject := "Teams360 - Password Reset"
+	subject := "Team Health Check - Password Reset"
 	body := fmt.Sprintf(`<html><body>
 <h2>Password Reset Request</h2>
-<p>You requested a password reset for your Teams360 account.</p>
+<p>You requested a password reset for your Team Health Check account.</p>
 <p>Your reset token is: <strong>%s</strong></p>
 <p>This token will expire in 1 hour.</p>
 <p>If you did not request this, please ignore this email.</p>

--- a/backend/infrastructure/email/smtp_service.go
+++ b/backend/infrastructure/email/smtp_service.go
@@ -132,10 +132,10 @@ func (s *SMTPEmailService) SendHTML(ctx context.Context, to, subject, htmlBody s
 
 // SendPasswordResetEmail implements the EmailService interface from password_reset_service.go.
 func (s *SMTPEmailService) SendPasswordResetEmail(ctx context.Context, emailAddr, resetToken string) error {
-	subject := "Teams360 - Password Reset"
+	subject := "Team Health Check - Password Reset"
 	body := fmt.Sprintf(`<html><body>
 <h2>Password Reset Request</h2>
-<p>You requested a password reset for your Teams360 account.</p>
+<p>You requested a password reset for your Team Health Check account.</p>
 <p>Your reset token is: <strong>%s</strong></p>
 <p>This token will expire in 1 hour.</p>
 <p>If you did not request this, please ignore this email.</p>

--- a/backend/infrastructure/email/templates.go
+++ b/backend/infrastructure/email/templates.go
@@ -113,7 +113,7 @@ func RenderIndividualSurveyEmail(data IndividualSurveyEmailData) string {
 <tr><td align="center">
 <table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
   <tr><td style="background:#1E40AF;padding:24px 32px;">
-    <h1 style="margin:0;color:#fff;font-size:20px;">Teams360</h1>
+    <h1 style="margin:0;color:#fff;font-size:20px;">Team Health Check</h1>
     <p style="margin:4px 0 0;color:#BFDBFE;font-size:14px;">%s Submission Copy</p>
   </td></tr>
   <tr><td style="padding:24px 32px;">
@@ -137,7 +137,7 @@ func RenderIndividualSurveyEmail(data IndividualSurveyEmailData) string {
     <p style="margin:24px 0 0;color:#9CA3AF;font-size:12px;">This is an automated copy of your submission. No action is required.</p>
   </td></tr>
   <tr><td style="background:#F9FAFB;padding:16px 32px;text-align:center;">
-    <p style="margin:0;color:#9CA3AF;font-size:11px;">Teams360 — Team Health Check Platform</p>
+    <p style="margin:0;color:#9CA3AF;font-size:11px;">Team Health Check — Team Health Check Platform</p>
   </td></tr>
 </table>
 </td></tr>
@@ -181,7 +181,7 @@ func RenderTeamSummaryEmail(data TeamSummaryEmailData) string {
 <tr><td align="center">
 <table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
   <tr><td style="background:#7C3AED;padding:24px 32px;">
-    <h1 style="margin:0;color:#fff;font-size:20px;">Teams360</h1>
+    <h1 style="margin:0;color:#fff;font-size:20px;">Team Health Check</h1>
     <p style="margin:4px 0 0;color:#DDD6FE;font-size:14px;">Post-Workshop Survey Summary</p>
   </td></tr>
   <tr><td style="padding:24px 32px;">
@@ -202,10 +202,10 @@ func RenderTeamSummaryEmail(data TeamSummaryEmailData) string {
         %s
       </tbody>
     </table>
-    <p style="margin:24px 0 0;color:#9CA3AF;font-size:12px;">This is an automated summary. Log in to Teams360 for full analytics.</p>
+    <p style="margin:24px 0 0;color:#9CA3AF;font-size:12px;">This is an automated summary. Log in to Team Health Check for full analytics.</p>
   </td></tr>
   <tr><td style="background:#F9FAFB;padding:16px 32px;text-align:center;">
-    <p style="margin:0;color:#9CA3AF;font-size:11px;">Teams360 — Team Health Check Platform</p>
+    <p style="margin:0;color:#9CA3AF;font-size:11px;">Team Health Check — Team Health Check Platform</p>
   </td></tr>
 </table>
 </td></tr>

--- a/backend/infrastructure/persistence/postgres/organization_repository.go
+++ b/backend/infrastructure/persistence/postgres/organization_repository.go
@@ -23,9 +23,12 @@ func NewOrganizationRepository(db *sql.DB) organization.Repository {
 func (r *OrganizationRepository) Get(ctx context.Context) (*organization.OrganizationConfig, error) {
 	var config organization.OrganizationConfig
 
-	// For now, construct config from hierarchy_levels
+	// Construct config from hierarchy_levels and app_settings
 	config.ID = "default"
-	config.CompanyName = "Team360"
+	config.CompanyName = "My Company"
+	if settings, err := r.GetAppSettings(ctx); err == nil && settings.CompanyName != "" {
+		config.CompanyName = settings.CompanyName
+	}
 	config.TeamMemberLevelID = "level-5" // Default team member level
 
 	// Fetch hierarchy levels

--- a/backend/tests/integration/organization_repository_test.go
+++ b/backend/tests/integration/organization_repository_test.go
@@ -1,0 +1,65 @@
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/agopalakrishnan/teams360/backend/domain/organization"
+	"github.com/agopalakrishnan/teams360/backend/infrastructure/persistence/postgres"
+	"github.com/agopalakrishnan/teams360/backend/tests/testhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OrganizationRepository", func() {
+	var (
+		db      *sql.DB
+		cleanup func()
+		repo    organization.Repository
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		db, cleanup = testhelpers.SetupTestDatabase()
+		repo = postgres.NewOrganizationRepository(db)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("Get CompanyName fallback and configuration loading", func() {
+		Context("when app_settings has no company_name configured or row is missing", func() {
+			It("falls back to 'My Company'", func() {
+				// Clear any app_settings row if present
+				_, err := db.ExecContext(ctx, "DELETE FROM app_settings")
+				Expect(err).NotTo(HaveOccurred())
+
+				config, err := repo.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.CompanyName).To(Equal("My Company"))
+			})
+
+			It("falls back to 'My Company' when GetAppSettings is called on an empty app_settings table", func() {
+				_, err := db.ExecContext(ctx, "DELETE FROM app_settings")
+				Expect(err).NotTo(HaveOccurred())
+
+				settings, err := repo.GetAppSettings(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(settings.CompanyName).To(Equal("My Company"))
+			})
+		})
+
+		Context("when app_settings contains a custom company_name", func() {
+			It("loads the stored company_name in Get()", func() {
+				err := repo.UpdateBrandingSettings(ctx, "Acme Corporation", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				config, err := repo.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.CompanyName).To(Equal("Acme Corporation"))
+			})
+		})
+	})
+})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Team360 Docker Compose - Local Development with PostgreSQL
+# Team Health Check Docker Compose - Local Development with PostgreSQL
 # Use this for local development only - NOT for production
 # =============================================================================
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Team360 Docker Compose - Application Services Only
+# Team Health Check Docker Compose - Application Services Only
 # Database must be provided externally (see docs/DOCKER.md for details)
 # =============================================================================
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# Team360 Architecture Documentation
+# Team Health Check Architecture Documentation
 
-This document provides a comprehensive overview of Team360's architecture, including system design, data flow, database schema, and technology decisions.
+This document provides a comprehensive overview of Team Health Check's architecture, including system design, data flow, database schema, and technology decisions.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ This document provides a comprehensive overview of Team360's architecture, inclu
 
 ## System Overview
 
-Team360 is a full-stack web application built with a **decoupled frontend-backend architecture**:
+Team Health Check is a full-stack web application built with a **decoupled frontend-backend architecture**:
 
 ```
 ┌─────────────────┐     HTTP/JSON     ┌─────────────────┐     SQL      ┌─────────────────┐

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,4 +1,4 @@
-# Code Review Findings Report: Team360 Codebase
+# Code Review Findings Report: Team Health Check Codebase
 
 **Review Date**: November 26, 2025
 **Reviewers**: Staff Engineers (Paired Review)
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-After reviewing the Team360 codebase (Go backend with Gin, Next.js frontend, Ginkgo/Gomega testing), we've identified several opportunities for harmonization, improved consistency, and simplification. The codebase shows good architectural intent with DDD principles, but has accumulated some inconsistencies that should be addressed.
+After reviewing the Team Health Check codebase (Go backend with Gin, Next.js frontend, Ginkgo/Gomega testing), we've identified several opportunities for harmonization, improved consistency, and simplification. The codebase shows good architectural intent with DDD principles, but has accumulated some inconsistencies that should be addressed.
 
 ---
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,6 +1,6 @@
 # Docker Deployment Guide
 
-This guide explains how to deploy Team360 using Docker containers.
+This guide explains how to deploy Team Health Check using Docker containers.
 
 ## Quick Start
 
@@ -12,7 +12,7 @@ This guide explains how to deploy Team360 using Docker containers.
 
 ### Production Deployment
 
-Team360 containers require an external PostgreSQL database. The database is NOT included in the container images to follow security best practices.
+Team Health Check containers require an external PostgreSQL database. The database is NOT included in the container images to follow security best practices.
 
 #### 1. Create Environment File
 
@@ -102,7 +102,7 @@ This starts:
 
 ### Supported Databases
 
-Team360 requires PostgreSQL 14 or higher. Tested with:
+Team Health Check requires PostgreSQL 14 or higher. Tested with:
 - PostgreSQL 14, 15, 16, 17
 - Amazon RDS for PostgreSQL
 - Google Cloud SQL for PostgreSQL

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,6 +1,6 @@
 # GitHub Actions Documentation
 
-This document describes the GitHub Actions workflows used in the Team360 project for CI/CD, security scanning, and automated dependency management.
+This document describes the GitHub Actions workflows used in the Team Health Check project for CI/CD, security scanning, and automated dependency management.
 
 ## Quick Reference
 

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -1,6 +1,6 @@
 # Makefile Documentation
 
-This document describes all available Make targets for the Team360 project. The Makefile orchestrates both the frontend (Next.js/TypeScript) and backend (Go/Gin) services.
+This document describes all available Make targets for the Team Health Check project. The Makefile orchestrates both the frontend (Next.js/TypeScript) and backend (Go/Gin) services.
 
 ## Quick Reference
 
@@ -90,7 +90,7 @@ make run
 
 **Output:**
 ```
-Starting Team360...
+Starting Team Health Check...
 
   Frontend: http://localhost:3000
   Backend:  http://localhost:8080
@@ -363,7 +363,7 @@ make status
 
 **Output example:**
 ```
-Team360 Project Status
+Team Health Check Project Status
 
 Frontend (Next.js 15 + TypeScript):
   Location: ./frontend

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,6 +1,6 @@
-# Team360 Observability Guide
+# Team Health Check Observability Guide
 
-Team360 provides comprehensive observability through **metrics**, **distributed tracing**, and **structured logging**. The system is designed to be backend-agnostic, allowing you to use your preferred observability platform.
+Team Health Check provides comprehensive observability through **metrics**, **distributed tracing**, and **structured logging**. The system is designed to be backend-agnostic, allowing you to use your preferred observability platform.
 
 ## Table of Contents
 
@@ -25,7 +25,7 @@ Team360 provides comprehensive observability through **metrics**, **distributed 
 
 ## Architecture Overview
 
-Team360 uses **OpenTelemetry (OTel)** as the telemetry standard, providing vendor-agnostic instrumentation:
+Team Health Check uses **OpenTelemetry (OTel)** as the telemetry standard, providing vendor-agnostic instrumentation:
 
 ```
 ┌─────────────────┐      ┌──────────────────┐      ┌─────────────────────┐
@@ -87,7 +87,7 @@ make run-with-otel
 
 ## Metrics
 
-Team360 exposes 40+ metrics organized into six categories. All metrics use the `teams360_` prefix when exported through Prometheus.
+Team Health Check exposes 40+ metrics organized into six categories. All metrics use the `teams360_` prefix when exported through Prometheus.
 
 ### User Engagement Metrics
 
@@ -183,7 +183,7 @@ groups:
 
 ### Survey/Health Check Metrics
 
-These are the **core product metrics** for Team360, tracking health check survey participation and quality. These metrics directly measure whether the product is delivering value.
+These are the **core product metrics** for Team Health Check, tracking health check survey participation and quality. These metrics directly measure whether the product is delivering value.
 
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|--------|
@@ -216,7 +216,7 @@ These are the **core product metrics** for Team360, tracking health check survey
 
 #### Understanding the Health Score Scale
 
-Team360 uses a 3-point scale based on Spotify's model:
+Team Health Check uses a 3-point scale based on Spotify's model:
 
 | Score | Color | Meaning | Action |
 |-------|-------|---------|--------|
@@ -758,7 +758,7 @@ groups:
 
 ## Distributed Tracing
 
-Team360 implements distributed tracing using OpenTelemetry with named tracers for different domains:
+Team Health Check implements distributed tracing using OpenTelemetry with named tracers for different domains:
 
 ### Tracer Names
 
@@ -787,7 +787,7 @@ span.SetAttributes(
 
 ### Trace Context Propagation
 
-Team360 uses W3C TraceContext for distributed tracing across services:
+Team Health Check uses W3C TraceContext for distributed tracing across services:
 
 ```go
 // Propagators configured in telemetry initialization
@@ -815,7 +815,7 @@ func maskUsername(username string) string {
 
 ## Structured Logging
 
-Team360 uses **zerolog** for high-performance structured logging with automatic trace correlation.
+Team Health Check uses **zerolog** for high-performance structured logging with automatic trace correlation.
 
 ### Log Levels
 
@@ -898,7 +898,7 @@ logger.Init(logger.Config{
 
 ## Grafana Dashboard
 
-Team360 ships with a pre-configured Grafana dashboard (`Team360 Product Analytics`) containing 18 panels organized into three sections.
+Team Health Check ships with a pre-configured Grafana dashboard (`Team Health Check Product Analytics`) containing 18 panels organized into three sections.
 
 ### User Engagement Overview
 
@@ -1125,7 +1125,7 @@ sampler := trace.ParentBased(
 
 ### Metric Cardinality
 
-High-cardinality labels can cause storage issues. Team360 limits cardinality by:
+High-cardinality labels can cause storage issues. Team Health Check limits cardinality by:
 - Not including `user_id` on high-volume metrics
 - Using `team_id` selectively (11 teams max by default)
 - Aggregating paths/endpoints rather than full URLs

--- a/fix-mac-issues.sh
+++ b/fix-mac-issues.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "🔧 Team360 Health Check - Mac ARM64 Fix Script"
+echo "🔧 Team Health Check - Mac ARM64 Fix Script"
 echo "=============================================="
 
 # Check if we're on macOS

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Team360 Frontend
+# Team Health Check Frontend
 
-Next.js 15 application for the Team360 Squad Health Check system.
+Next.js 15 application for the Team Health Check Squad Health Check system.
 
 ## Quick Start
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Team Health Check Frontend
 
-Next.js 15 application for the Team Health Check Squad Health Check system.
+Next.js 15 application for the Team Health Check system.
 
 ## Quick Start
 

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -222,7 +222,7 @@ export default function MemberHomePage() {
                 <Building2 className="h-8 w-8 text-blue-600" />
               )}
               <div>
-                <h1 className="text-xl font-bold text-gray-900">{brandingName || 'Team360'}</h1>
+                <h1 className="text-xl font-bold text-gray-900">{brandingName || 'Team Health Check'}</h1>
                 <p className="text-sm text-gray-500">Member Home</p>
               </div>
             </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,7 +7,7 @@ import AuthGuard from "@/components/AuthGuard";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Team360 Health Check",
+  title: "Team Health Check",
   description: "Squad Health Check Model - Track and improve your team&apos;s health",
 };
 

--- a/frontend/components/OnboardingModal.tsx
+++ b/frontend/components/OnboardingModal.tsx
@@ -10,11 +10,11 @@ interface OnboardingModalProps {
 
 const SLIDES = [
   {
-    title: 'Welcome to Teams360',
+    title: 'Welcome to Team Health Check',
     content: (
       <div className="space-y-3 text-sm text-gray-600">
         <p>
-          Teams360 is a safe space for your team to reflect on how you are working together.
+          Team Health Check is a safe space for your team to reflect on how you are working together.
           It is based on the{' '}
           <span className="font-medium text-gray-800">Spotify Squad Health Check Model</span>.
         </p>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.12",
+        "happy-dom": "^20.11.1",
         "jsdom": "^27.2.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
@@ -3094,6 +3095,23 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
@@ -4266,6 +4284,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/call-bind": {
@@ -6232,6 +6263,48 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -10231,9 +10304,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "team360-health-check",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -45,6 +46,7 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.12",
+    "happy-dom": "^20.11.1",
     "jsdom": "^27.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     include: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],

--- a/kubevela/teams360-kubevela.yaml
+++ b/kubevela/teams360-kubevela.yaml
@@ -1,4 +1,4 @@
-# Team360 KubeVela Application Manifest
+# Team Health Check KubeVela Application Manifest
 # Deploys: CNPG PostgreSQL + unified app (Go API serving static frontend)
 # Usage: kubectl apply -f kubevela/teams360-kubevela.yaml
 #

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script to start development server on host machine with SSL bypass
 
-echo "Starting Team360 Health Check Application..."
+echo "Starting Team Health Check Application..."
 echo "----------------------------------------"
 
 # Set environment variable to bypass SSL certificate check


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rebrand the product from Team360 to Team Health Check across the app and docs, and improve organization branding config with a safe default and tests. Also switch the frontend test environment to `happy-dom`.

- **Refactors**
  - Renamed all user-facing strings: UI, emails, logs, docs, Makefiles, and Grafana dashboards.
  - Backend: organization config now reads company name from app settings; falls back to "My Company" when unset; added integration tests.
  - Frontend: updated default branding fallback and page metadata to "Team Health Check".

- **Dependencies**
  - Frontend tests now run with `happy-dom` (replacing `jsdom`) via Vitest config.
  - Added `"type": "module"` to `frontend/package.json`.

<sup>Written for commit d4dccb90081e3e34c16ceb1ce110d9a626914b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/teams360/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

